### PR TITLE
Fix restart_on_changed helper

### DIFF
--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -217,13 +217,12 @@ class OpenStackBaseTest(unittest.TestCase):
                 services,
                 model_name=self.model_name)
 
-            logging.debug(
-                'Waiting for updates to propagate to '.format(config_file))
-            model.block_until_oslo_config_entries_match(
-                self.application_name,
-                config_file,
-                default_entry,
-                model_name=self.model_name)
+        logging.debug('Waiting for updates to propagate to '.format(config_file))
+        model.block_until_oslo_config_entries_match(
+            self.application_name,
+            config_file,
+            default_entry,
+            model_name=self.model_name)
 
     @contextlib.contextmanager
     def pause_resume(self, services):


### PR DESCRIPTION
The restart_on_changed helper was moved to use the config_change
context manager but the code that checks that the config file is
correctly reverted at the end of the test was accidently left within
the context.