### PR TITLE
Expose resource_removeds retry options

### DIFF
--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -217,7 +217,8 @@ class OpenStackBaseTest(unittest.TestCase):
                 services,
                 model_name=self.model_name)
 
-        logging.debug('Waiting for updates to propagate to '.format(config_file))
+        logging.debug(
+            'Waiting for updates to propagate to '.format(config_file))
         model.block_until_oslo_config_entries_match(
             self.application_name,
             config_file,


### PR DESCRIPTION
resource_removed is used in many places to monitor removal of
different kinds of OpenStack resource. It is reasonable to expect a
flavor to be removed in a few seconds where as an image based instance
may take minutes to be removed. With that in mind this change
exposes the retry options used by tenacity allowing the caller to
set reasonable expectations for the resource removal.