### PR TITLE
octavia/diskimage-retrofit: Add charm setup and tests

### DIFF
--- a/zaza/openstack/charm_tests/octavia/diskimage_retrofit/__init__.py
+++ b/zaza/openstack/charm_tests/octavia/diskimage_retrofit/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collection of code for setting up and testing octavia-diskimage-retrofit."""

--- a/zaza/openstack/charm_tests/octavia/diskimage_retrofit/setup.py
+++ b/zaza/openstack/charm_tests/octavia/diskimage_retrofit/setup.py
@@ -23,6 +23,10 @@ def retrofit_amphora_image(unit='octavia-diskimage-retrofit/0',
                            force=False, image_id=None):
     """Run action to retrofit Ubuntu Cloud image into Octavia ``amphora``.
 
+    :param unit: Name of unit to operate on
+    :type: unit: str
+    :param force: Force re-creation of image if it exists
+    :type force: bool
     :param image_id: Glance image ID used as source for retrofitting.
                      (Default is to find it based on image properties.)
     :type image_id: str
@@ -41,7 +45,6 @@ def retrofit_amphora_image(unit='octavia-diskimage-retrofit/0',
     action = zaza.model.run_action(
         unit,
         'retrofit-image',
-        action_params=params)
-    if not action or action.status != 'completed':
-        raise Exception('run-action failed: "{}"'.format(action))
+        action_params=params,
+        raise_on_failure=True)
     return action

--- a/zaza/openstack/charm_tests/octavia/diskimage_retrofit/setup.py
+++ b/zaza/openstack/charm_tests/octavia/diskimage_retrofit/setup.py
@@ -1,0 +1,47 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Code for configuring octavia-diskimage-retrofit."""
+
+import logging
+
+import zaza.model
+
+
+def retrofit_amphora_image(unit='octavia-diskimage-retrofit/0',
+                           force=False, image_id=None):
+    """Run action to retrofit Ubuntu Cloud image into Octavia ``amphora``.
+
+    :param image_id: Glance image ID used as source for retrofitting.
+                     (Default is to find it based on image properties.)
+    :type image_id: str
+    :raises:Exception if action does not complete successfully.
+    """
+    logging.info('Running `retrofit-image` action on {}'.format(unit))
+    params = {}
+    if force:
+        params.update({'force': force})
+    if image_id:
+        params.update({'source-image': image_id})
+
+    # NOTE(fnordahl) ``zaza.model.run_action_on_leader`` fails here,
+    # apparently has to do with handling of subordinates in ``libjuju`` or
+    # ``juju`` itself.
+    action = zaza.model.run_action(
+        unit,
+        'retrofit-image',
+        action_params=params)
+    if not action or action.status != 'completed':
+        raise Exception('run-action failed: "{}"'.format(action))
+    return action

--- a/zaza/openstack/charm_tests/octavia/diskimage_retrofit/tests.py
+++ b/zaza/openstack/charm_tests/octavia/diskimage_retrofit/tests.py
@@ -1,0 +1,62 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate ``octavia-diskimage-retrofit`` testing."""
+import logging
+
+import zaza.model
+
+import zaza.openstack.utilities.openstack as openstack
+import zaza.openstack.charm_tests.test_utils as test_utils
+
+
+class OctaviaDiskimageRetrofitTest(test_utils.OpenStackBaseTest):
+    """Encapsulate ``octavia-diskimage-retrofit`` tests.
+
+    Note that a full end to end test is performed by using the
+    ``octavia-diskimage-retrofit`` charm for building amphora image
+    used in the ``octavia`` charm functional tests.
+    """
+
+    def test_retrofit_image(self):
+        """Run ``retrofit-image`` action."""
+        action = zaza.model.run_action(
+            'octavia-diskimage-retrofit/0',
+            'retrofit-image',
+            action_params={})
+        self.assertEqual(action.status, 'completed')
+        logging.info('Run it again, expect failure')
+        action = zaza.model.run_action(
+            'octavia-diskimage-retrofit/0',
+            'retrofit-image',
+            action_params={})
+        self.assertEqual(action.status, 'failed')
+        logging.info('Run it again, with force')
+        action = zaza.model.run_action(
+            'octavia-diskimage-retrofit/0',
+            'retrofit-image',
+            action_params={'force': True})
+        self.assertEqual(action.status, 'completed')
+
+    def test_retrofit_image_source_image(self):
+        """Run ``retrofit-image`` action specifying source image."""
+        session = openstack.get_overcloud_keystone_session()
+        glance = openstack.get_glance_session_client(session)
+        source_image = glance.images.list(filters={'os_distro': 'ubuntu',
+                                                   'os_version': '18.04'})
+        action = zaza.mode.run_action(
+            'octavia-diskimage-retrofit/0',
+            'retrofit-image',
+            action_params={'source-image': source_image.id})
+        self.assertEqual(action.status, 'completed')


### PR DESCRIPTION
Setup can be used standalone by other charms consuming the
``octavia-diskimage-retrofit`` charm for their testing purposes.

Tests the charms actions.

Full end to end test will be done by consuming this charm in the
``octavia`` charm tests.