### PR TITLE
Allow test to override application name

### DIFF
--- a/zaza/openstack/charm_tests/keystone/__init__.py
+++ b/zaza/openstack/charm_tests/keystone/__init__.py
@@ -32,7 +32,7 @@ class BaseKeystoneTest(test_utils.OpenStackBaseTest):
     @classmethod
     def setUpClass(cls):
         """Run class setup for running Keystone charm operation tests."""
-        super(BaseKeystoneTest, cls).setUpClass()
+        super(BaseKeystoneTest, cls).setUpClass(application_name='keystone')
         # Check if we are related to Vault TLS certificates
         cls.tls_rid = zaza.model.get_relation_id(
             'keystone', 'vault', remote_interface_name='certificates')

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -73,12 +73,15 @@ class OpenStackBaseTest(unittest.TestCase):
     """Generic helpers for testing OpenStack API charms."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls, application_name=None):
         """Run setup for test class to create common resourcea."""
         cls.keystone_session = openstack_utils.get_overcloud_keystone_session()
         cls.model_name = model.get_juju_model()
         cls.test_config = lifecycle_utils.get_charm_config()
-        cls.application_name = cls.test_config['charm_name']
+        if application_name:
+            cls.application_name = application_name
+        else:
+            cls.application_name = cls.test_config['charm_name']
         cls.lead_unit = model.get_lead_unit_name(
             cls.application_name,
             model_name=cls.model_name)


### PR DESCRIPTION
Allow tests to override the default application name as it may not
match what is in the tests.yaml, particularly in the case of CMR
tests.