### PR TITLE
octavia: Fix gathering of payload ips

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ PyYAML<=4.2,>=3.0
 flake8>=2.2.4,<=3.5.0
 flake8-docstrings
 flake8-per-file-ignores
+pydocstyle<4.0.0
 coverage
 mock>=1.2
 nose>=1.3.7


### PR DESCRIPTION
The existing code lead to intermittent failures as there are a few
Neutron ports tagged with ``device:owner`` ``compute:nova`` that
has nothing to do with our payload instances.

Get IP information by asking Nova to list instances instead.