### PR TITLE
Ceilometer is in a blocked state until action run

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -129,7 +129,12 @@ WORKLOAD_STATUS_EXCEPTIONS = {
         'workload-status': 'unknown',
         'workload-status-message': ''},
     'postgresql': {
-        'workload-status-message': 'Live'}}
+        'workload-status-message': 'Live'},
+    'ceilometer': {
+        'workload-status': 'blocked',
+        'workload-status-message':
+            ('Run the ceilometer-upgrade action on the leader to initialize '
+             'ceilometer and gnocchi')}}
 
 # For vault TLS certificates
 KEYSTONE_CACERT = "keystone_juju_ca_cert.crt"


### PR DESCRIPTION
For a full stack deployment ceilometer will be in a blocked state waiting
on the ceilometer-action run.

Add this to the workload exceptions dict.