### PR TITLE
Add a subordinate blacklist for pausing services

### DIFF
--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -291,7 +291,8 @@ def series_upgrade_application(application, pause_non_leader_primary=True,
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    if subordinate in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
+                    _app = subordinate.split('/')[0]
+                    if _app in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
                         logging.info("Skipping pausing {} - blacklisted"
                                      .format(subordinate))
                     else:

--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -27,6 +27,11 @@ from zaza.openstack.utilities import exceptions as zaza_exceptions
 from zaza.openstack.utilities.os_versions import UBUNTU_OPENSTACK_RELEASE
 
 
+SUBORDINATE_PAUSE_RESUME_BLACKLIST = [
+    "cinder-ceph",
+]
+
+
 def dict_to_yaml(dict_data):
     """Return YAML from dictionary.
 
@@ -286,8 +291,13 @@ def series_upgrade_application(application, pause_non_leader_primary=True,
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    logging.info("Pausing {}".format(subordinate))
-                    model.run_action(subordinate, "pause", action_params={})
+                    if subordinate in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
+                        logging.info("Skipping pausing {} - blacklisted"
+                                     .format(subordinate))
+                    else:
+                        logging.info("Pausing {}".format(subordinate))
+                        model.run_action(
+                            subordinate, "pause", action_params={})
         if pause_non_leader_primary:
             logging.info("Pausing {}".format(unit))
             model.run_action(unit, "pause", action_params={})


### PR DESCRIPTION
During the series upgrade tests, zaza pauses subordinate services.
However, the cinder-ceph charm has no pause/resume action, and so the
test fails.  This PR adds a blacklist that ensures that the cinder-ceph
subordinate is not paused during series upgrade.