### PR TITLE
Verify instances status before going starting the instances

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -276,13 +276,10 @@ class PerconaClusterColdStartTest(PerconaClusterTest):
         logging.info("Stopping instances: {}".format(self.machines))
         for uuid in self.machines:
             self.nova_client.servers.stop(uuid)
-        # Unfortunately, juju reports units in workload status "active"
-        # when they are in fact down. So we have to rely on a simple wait
-        # and idle check.
-        logging.debug("Sleep ...")
-        time.sleep(30)
-        logging.debug("Wait till model is idle ...")
-        zaza.model.block_until_all_units_idle()
+        logging.debug("Wait till all machines are shutoff ...")
+        for uuid in self.machines:
+            openstack_utils.resource_reaches_status(self.nova_client.servers, uuid,
+                                                    expected_status='SHUTOFF', stop_after_attempt=16)
 
         # Start nodes
         self.machines.sort(reverse=True)

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -278,8 +278,10 @@ class PerconaClusterColdStartTest(PerconaClusterTest):
             self.nova_client.servers.stop(uuid)
         logging.debug("Wait till all machines are shutoff ...")
         for uuid in self.machines:
-            openstack_utils.resource_reaches_status(self.nova_client.servers, uuid,
-                                                    expected_status='SHUTOFF', stop_after_attempt=16)
+            openstack_utils.resource_reaches_status(self.nova_client.servers,
+                                                    uuid,
+                                                    expected_status='SHUTOFF',
+                                                    stop_after_attempt=16)
 
         # Start nodes
         self.machines.sort(reverse=True)


### PR DESCRIPTION
This PR is to resolve issue https://github.com/openstack-charmers/zaza-openstack-tests/issues/44
By waiting for a confirmed "shutoff" status of each of the 3 instances in the test, instead of waiting 30 sec, will assure that we do not run into a nova error of the type `novaclient.exceptions.Conflict: Cannot 'start' instance 921dd945-fd52-417c-abc7-3868a33701a4 while it is in vm_state active`.

Moreover, the check of the "idle" juju status is not necessary, because when the instances are shutoff, the units enter a state of "Agent lost", which does not mean that the instances are fully shutdown, simply that juju is not able to communicate with their agent anymore. 