### PR TITLE
Add ceph-proxy cinder-ceph setup test

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -706,7 +706,31 @@ class CephProxyTest(unittest.TestCase):
 
     def test_ceph_health(self):
         """Make sure ceph-proxy can communicate with ceph."""
+        logging.info('Wait for idle/ready status...')
+        zaza_model.wait_for_application_states()
+
         self.assertEqual(
             zaza_model.run_on_leader("ceph-proxy", "sudo ceph health")["Code"],
             "0"
         )
+
+    def test_cinder_ceph_restrict_pool_setup(self):
+        """Make sure cinder-ceph restrict pool was created successfully."""
+        logging.info('Wait for idle/ready status...')
+        zaza_model.wait_for_application_states()
+
+        pools = zaza_ceph.get_ceph_pools('ceph-mon/0')
+        if 'cinder-ceph' not in pools:
+            msg = 'cinder-ceph pool was not found upon querying ceph-mon/0'
+            raise zaza_exceptions.CephPoolNotFound(msg)
+
+        expected = "pool=cinder-ceph, allow class-read " \
+                   "object_prefix rbd_children"
+        cmd = "sudo ceph auth get client.cinder-ceph"
+        result = zaza_model.run_on_unit('ceph-mon/0', cmd)
+        output = result.get('Stdout').strip()
+
+        if expected not in output:
+            msg = ('cinder-ceph pool restriction was not configured correctly.'
+                   ' Found: {}'.format(output))
+            raise zaza_exceptions.CephPoolNotConfigured(msg)

--- a/zaza/openstack/utilities/exceptions.py
+++ b/zaza/openstack/utilities/exceptions.py
@@ -162,6 +162,12 @@ class CephPoolNotFound(Exception):
     pass
 
 
+class CephPoolNotConfigured(Exception):
+    """Ceph pool not configured properly."""
+
+    pass
+
+
 class NovaGuestMigrationFailed(Exception):
     """Nova guest migration failed."""
 


### PR DESCRIPTION
This change adds a functional test that verifies
ceph-proxy has successfully created a cinder-ceph
restricted ceph pool.

Related-Bug: lp#1836408