### PR TITLE
Add initial policyd initial test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps = -r{toxinidir}/requirements.txt
 commands = /bin/true
 
 [flake8]
-ignore = E402,E226
+ignore = E402,E226,W504
 per-file-ignores =
   unit_tests/**: D
 

--- a/zaza/openstack/charm_tests/keystone/__init__.py
+++ b/zaza/openstack/charm_tests/keystone/__init__.py
@@ -30,7 +30,7 @@ class BaseKeystoneTest(test_utils.OpenStackBaseTest):
     """Base for Keystone charm tests."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls, application_name=None):
         """Run class setup for running Keystone charm operation tests."""
         super(BaseKeystoneTest, cls).setUpClass(application_name='keystone')
         # Check if we are related to Vault TLS certificates

--- a/zaza/openstack/charm_tests/policyd/__init__.py
+++ b/zaza/openstack/charm_tests/policyd/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Collection of code for setting up and testing policyd overrides across a
+"""Policyd.
+
+Collection of code for setting up and testing policyd overrides across a
 collection of charms.
 """

--- a/zaza/openstack/charm_tests/policyd/__init__.py
+++ b/zaza/openstack/charm_tests/policyd/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collection of code for setting up and testing policyd overrides across a
+collection of charms.
+"""

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -21,6 +21,7 @@ import tempfile
 import zipfile
 
 import zaza.model as zaza_model
+import zaza.utilities.juju as zaza_juju
 
 import zaza.openstack.charm_tests.test_utils as test_utils
 import zaza.openstack.utilities.openstack as openstack_utils
@@ -112,6 +113,8 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         zaza_model.block_until_all_units_idle()
         # check that the status includes "PO:" at the beginning of the status
         # line
+        app_status = zaza_juju.get_application_status(self.application_name)
+        logging.info("App status is: {}".format(app_status))
 
         # disable the policy override
         # verify that the file no longer exists

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -138,7 +138,7 @@ async def async_block_until_wl_status_info_starts_with(
     async def _unit_status():
         model_status = await zaza_model.async_get_status()
         wl_infos = [v['workload-status']['info']
-                    for k, v in model_status.applications[app]['units']
+                    for k, v in model_status.applications[app]['units'].items()
                     if k.split('/')[0] == app]
         g = (s.startswith(status) for s in wl_infos)
         if negate_match:

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -60,8 +60,9 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         self._set_config_and_wait(False)
 
     def _set_config_and_wait(self, state):
+        s = "true" if state else "false"
         zaza_model.set_application_config(self.application_name,
-                                          {"use-policyd-override": state})
+                                          {"use-policyd-override": s})
         zaza_model.block_until_all_units_idle()
 
     def _make_zip_file_from(self, name, files):

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -20,17 +20,13 @@ import shutil
 import tempfile
 import zipfile
 
-from juju.errors import JujuError
-
-import zaza
 import zaza.model as zaza_model
-import zaza.utilities.juju as zaza_juju
 
 import zaza.openstack.charm_tests.test_utils as test_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 
 
-class PolicydTest(test_utils.OpenStackBaseTest):
+class PolicydTest(object):
     """Charm operation tests.
 
     The policyd test needs some config from the tests.yaml in order to work
@@ -90,13 +86,13 @@ class PolicydTest(test_utils.OpenStackBaseTest):
             'file1.yaml': "{'rule1': '!'}"
         }
         good_zip_path = self._make_zip_file_from('good.zip', good)
-        logging.info("About to attach the resource")
+        logging.info("Attaching a resource.")
         zaza_model.attach_resource(self.application_name,
                                    'policyd-override',
                                    good_zip_path)
-        logging.info("... waiting for idle")
+        logging.debug("... waiting for idle")
         zaza_model.block_until_all_units_idle()
-        logging.info("Now setting config to true")
+        logging.debug("Now setting config to true")
         self._set_config(True)
         # check that the file gets to the right location
         path = os.path.join(
@@ -109,10 +105,10 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         logging.info("Checking for workload status line starts with PO:")
         zaza_model.block_until_wl_status_info_starts_with(
             self.application_name, "PO:")
-        logging.info("App status is valid")
+        logging.debug("App status is valid")
 
         # disable the policy override
-        logging.info("Disabling policy override ...")
+        logging.info("Disabling policy override by setting config to false")
         self._set_config(False)
         # check that the status no longer has "PO:" on it.
         # we have to do it twice due to async races and that some info lines
@@ -131,3 +127,13 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         zaza_model.block_until_file_missing(self.application_name, path)
 
         logging.info("...done")
+
+
+class KeystonePolicydTest(PolicydTest, test_utils.OpenStackBaseTest):
+    pass
+
+
+class GenericPolicydTest(PolicydTest, test_utils.OpenStackBaseTest):
+    pass
+
+

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -146,6 +146,10 @@ class KeystonePolicydTest(PolicydTest,
                           ch_keystone.BaseKeystoneTest,
                           test_utils.OpenStackBaseTest):
 
+    @classmethod
+    def setUpClass(cls, application_name=None):
+        super(KeystonePolicydTest, cls).setUpClass(application_name)
+
     def test_disable_service(self):
         self._set_policy_with({"identity:get_auth_domains": "!"})
         with self.config_change(

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -1,0 +1,97 @@
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate policyd testing."""
+
+import logging
+import os
+import shutil
+import tempfile
+import zipfile
+
+import zaza.model as zaza_model
+
+import zaza.openstack.charm_tests.test_utils as test_utils
+
+
+class PolicydTest(test_utils.OpenStackBaseTest):
+    """Charm operation tests.
+
+    The policyd test needs some config from the tests.yaml in order to work
+    properly.  A top level key of "tests_options".  Under that key is
+    'policyd', and then the k:v of 'service': <name>.  e.g. for keystone
+
+    tests_options:
+      policyd:
+        service: keystone
+    """
+
+    def setUpClass(cls, application_name=None):
+        super().setUpClass(application_name)
+        cls._tmp_dir = tempfile.mkdtemp()
+        cls._service_name = \
+            cls.test_config['tests_options']['policyd']['service']
+
+    def tearDownClass(cls):
+        super().tearDownClass()
+        try:
+            shutil.rmtree(cls._tmp_dir, ignore_errors=True)
+        except Exception as e:
+            logging.error("Removing the policyd tempdir/files failed: {}"
+                          .format(str(e)))
+
+    def tearDown(self):
+        """Ensure that the policyd config is switched off and the charm is
+        stable at the end of the test.
+        """
+        self._set_config_and_wait(False)
+
+    def _set_config_and_wait(self, state):
+        zaza_model.set_application_config(self.application_name,
+                                          {"use-policyd-override", state})
+        zaza_model.block_until_all_units_idle()
+
+    def _make_zip_file_from(self, name, files):
+        """Make a zip file from a dictionary of filename: string.
+
+        :param name: the name of the zip file
+        :type name: PathLike
+        :param files: a dict of name: string to construct the files from.
+        :type files: Dict[str, str]
+        :returns: temp file that is the zip file.
+        :rtype: PathLike
+        """
+        path = os.path.join(self._tmp_dir, name)
+        with zipfile.ZipFile(path, "w") as zfp:
+            for name, contents in files.items():
+                zfp.writestr(name, contents)
+
+    def test_policyd_good_yaml(self):
+        # Test that the policyd with a good zipped yaml file puts the yaml file
+        # in the right directory
+        good = {
+            'file1.yaml': "{'rule1': '!'}"
+        }
+        good_zip_path = self._make_zip_file_from('good.zip', good)
+        zaza_model.attach_resource(self.application_name,
+                                   'policyd-override',
+                                   good_zip_path)
+        zaza_model.block_until_all_units_idle()
+        self._set_config_and_wait(True)
+        # check that the file gets to the right location
+        path = os.path.join(
+            "/etc", self._service_name, "policy.d", 'file1.yaml')
+        zaza_model.block_until_file_has_contents(self.application_name,
+                                                 path,
+                                                 "'rule1': '!'")

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -38,13 +38,13 @@ class PolicydTest(test_utils.OpenStackBaseTest):
     """
 
     def setUpClass(cls, application_name=None):
-        super().setUpClass(application_name)
+        super(PolicydTest, cls).setUpClass(application_name)
         cls._tmp_dir = tempfile.mkdtemp()
         cls._service_name = \
             cls.test_config['tests_options']['policyd']['service']
 
     def tearDownClass(cls):
-        super().tearDownClass()
+        super(PolicydTest, cls).tearDownClass()
         try:
             shutil.rmtree(cls._tmp_dir, ignore_errors=True)
         except Exception as e:

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -155,8 +155,10 @@ class KeystonePolicydTest(PolicydTest,
         self._set_policy_with(
             {'rule.yaml': "{'identity:get_auth_domains': '!'}"})
         with self.config_change(
-                {'preferred-api-version': self.default_api_version},
-                {'preferred-api-version': '3'},
+                {'preferred-api-version': self.default_api_version,
+                 'use-policyd-override': 'False'},
+                {'preferred-api-version': '3',
+                 'use-policyd-override': 'True'},
                 application_name="keystone"):
             for ip in self.keystone_ips:
                 try:

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -61,7 +61,7 @@ class PolicydTest(test_utils.OpenStackBaseTest):
 
     def _set_config_and_wait(self, state):
         zaza_model.set_application_config(self.application_name,
-                                          {"use-policyd-override", state})
+                                          {"use-policyd-override": state})
         zaza_model.block_until_all_units_idle()
 
     def _make_zip_file_from(self, name, files):

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -66,7 +66,7 @@ class PolicydTest(test_utils.OpenStackBaseTest):
     def _set_config_and_wait(self, state):
         s = "True" if state else "False"
         config = {"use-policyd-override": s}
-        logging.info("Setting config to", config)
+        logging.info("Setting config to {}".format(config))
         zaza_model.set_application_config(self.application_name, config)
         zaza_model.block_until_all_units_idle()
 

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -184,13 +184,13 @@ class KeystonePolicydTest(PolicydTest,
                     keystone_client = (
                         openstack_utils.get_keystone_session_client(
                             keystone_session))
-                    keystone_client.projects.list()
+                    keystone_client.services.list()
                     logging.info("keystone IP:{} without policyd override "
-                                 "projects list working"
+                                 "services list working"
                                  .format(ip))
                 except keystoneauth1.exceptions.http.Forbidden:
                     raise zaza_exceptions.PolicydError(
-                        'Retrieve project list as demo user with project '
+                        'Retrieve services list as demo user with project '
                         'scoped token passed and should have passed. IP = {}'
                         .format(ip))
 

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -118,8 +118,20 @@ class PolicydTest(test_utils.OpenStackBaseTest):
                     for k, v in app_status['units'].items()
                     if k.split('/')[0] == self.application_name]
         logging.info("App status is: {}".format(wl_stats))
+        self.assertTrue(all(s.startswith("PO:") for s in wl_stats))
+        logging.info("App status is valid")
 
         # disable the policy override
-        # verify that the file no longer exists
+        logging.info("Disabling policy override ...")
+        self._set_config_and_wait(False)
         # check that the status no longer has "PO:" on it.
+        app_status = zaza_juju.get_application_status(self.application_name)
+        wl_stats = [v['workload-status']['info']
+                    for k, v in app_status['units'].items()
+                    if k.split('/')[0] == self.application_name]
+        self.assertFalse(any(s.startswith("PO:") for s in wl_stats))
+        logging.info("... done")
+
+        # verify that the file no longer exists
         logging.info("...done")
+

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -65,7 +65,7 @@ class PolicydTest(test_utils.OpenStackBaseTest):
 
     def _set_config_and_wait(self, state):
         s = "True" if state else "False"
-        config = {"user-policyd-override": s}
+        config = {"use-policyd-override": s}
         logging.info("Setting config to", config)
         zaza_model.set_application_config(self.application_name, config)
         zaza_model.block_until_all_units_idle()

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -77,6 +77,7 @@ class PolicydTest(object):
 
     @classmethod
     def setUpClass(cls, application_name=None):
+        """Run class setup for running Policyd charm operation tests."""
         super(PolicydTest, cls).setUpClass(application_name)
         if (openstack_utils.get_os_release() <
                 openstack_utils.get_os_release('xenial_queens')):
@@ -87,6 +88,7 @@ class PolicydTest(object):
 
     @classmethod
     def tearDownClass(cls):
+        """Run class tearDown for running Policyd charm operation tests."""
         super(PolicydTest, cls).tearDownClass()
         try:
             shutil.rmtree(cls._tmp_dir, ignore_errors=True)
@@ -126,8 +128,7 @@ class PolicydTest(object):
             self.application_name, "PO:", negate_match=True)
 
     def test_001_policyd_good_yaml(self):
-        # Test that the policyd with a good zipped yaml file puts the yaml file
-        # in the right directory
+        """Test that the policyd with a good zipped yaml file."""
         good = {
             'file1.yaml': "{'rule1': '!'}"
         }
@@ -174,8 +175,7 @@ class PolicydTest(object):
         logging.info("OK")
 
     def test_002_policyd_bad_yaml(self):
-        # Test that a bad yaml file in the zip file doesn't not put it in the
-        # override and puts up a status message that it is bad
+        """Test bad yaml file in the zip file is handled."""
         bad = {
             "file2.yaml": "{'rule': '!}"
         }
@@ -208,12 +208,15 @@ class PolicydTest(object):
 class KeystonePolicydTest(PolicydTest,
                           ch_keystone.BaseKeystoneTest,
                           test_utils.OpenStackBaseTest):
+    """Specific test for policyd for keystone charm."""
 
     @classmethod
     def setUpClass(cls, application_name=None):
+        """Run class setup for running KeystonePolicydTest tests."""
         super(KeystonePolicydTest, cls).setUpClass(application_name)
 
     def test_disable_service(self):
+        """Test that service can be disabled."""
         logging.info("Doing policyd override to disable listing domains")
         self._set_policy_with(
             {'rule.yaml': "{'identity:list_services': '!'}"})
@@ -301,4 +304,6 @@ class KeystonePolicydTest(PolicydTest,
 
 
 class GenericPolicydTest(PolicydTest, test_utils.OpenStackBaseTest):
+    """Generic policyd test for any charm without a specific test."""
+
     pass

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -154,6 +154,47 @@ class KeystonePolicydTest(PolicydTest,
         logging.info("Doing policyd override to disable listing domains")
         self._set_policy_with(
             {'rule.yaml': "{'identity:list_projects': '!'}"})
+
+        # verify (with the config off) that we can actually access
+        # these points
+        with self.config_change(
+                {'preferred-api-version': self.default_api_version},
+                {'preferred-api-version': '3'},
+                application_name="keystone"):
+            zaza_model.block_until_all_units_idle()
+            for ip in self.keystone_ips:
+                try:
+                    logging.info('keystone IP {}'.format(ip))
+                    openrc = {
+                        'API_VERSION': 3,
+                        'OS_USERNAME': ch_keystone.DEMO_ADMIN_USER,
+                        'OS_PASSWORD': ch_keystone.DEMO_ADMIN_USER_PASSWORD,
+                        'OS_AUTH_URL': 'http://{}:5000/v3'.format(ip),
+                        'OS_USER_DOMAIN_NAME': ch_keystone.DEMO_DOMAIN,
+                        'OS_DOMAIN_NAME': ch_keystone.DEMO_DOMAIN,
+                    }
+                    if self.tls_rid:
+                        openrc['OS_CACERT'] = \
+                            openstack_utils.KEYSTONE_LOCAL_CACERT
+                        openrc['OS_AUTH_URL'] = (
+                            openrc['OS_AUTH_URL'].replace('http', 'https'))
+                    logging.info('keystone IP {}'.format(ip))
+                    keystone_session = openstack_utils.get_keystone_session(
+                        openrc, scope='DOMAIN')
+                    keystone_client = (
+                        openstack_utils.get_keystone_session_client(
+                            keystone_session))
+                    keystone_client.projects.list()
+                    logging.info("keystone IP:{} without policyd override "
+                                 "projects list working"
+                                 .format(ip))
+                except keystoneauth1.exceptions.http.Forbidden:
+                    raise zaza_exceptions.PolicydError(
+                        'Retrieve project list as demo user with project '
+                        'scoped token passed and should have passed. IP = {}'
+                        .format(ip))
+
+        # now verify that the policy.d override does disable the endpoint
         with self.config_change(
                 {'preferred-api-version': self.default_api_version,
                  'use-policyd-override': 'False'},
@@ -192,7 +233,7 @@ class KeystonePolicydTest(PolicydTest,
                     logging.info("keystone IP:{} policyd override working"
                                  .format(ip))
 
-            logging.info('OK')
+        logging.info('OK')
 
 
 class GenericPolicydTest(PolicydTest, test_utils.OpenStackBaseTest):

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -88,14 +88,19 @@ class PolicydTest(test_utils.OpenStackBaseTest):
             'file1.yaml': "{'rule1': '!'}"
         }
         good_zip_path = self._make_zip_file_from('good.zip', good)
+        logging.info("About to attach the resource")
         zaza_model.attach_resource(self.application_name,
                                    'policyd-override',
                                    good_zip_path)
+        logging.info("... waiting for idle")
         zaza_model.block_until_all_units_idle()
+        logging.info("Now setting config to true")
         self._set_config_and_wait(True)
         # check that the file gets to the right location
         path = os.path.join(
             "/etc", self._service_name, "policy.d", 'file1.yaml')
+        logging.info("Now checking for file contents: {}".format(path))
         zaza_model.block_until_file_has_contents(self.application_name,
                                                  path,
                                                  "'rule1': '!'")
+        logging.info("...done")

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -92,7 +92,7 @@ class PolicydTest(object):
         zaza_model.block_until_wl_status_info_starts_with(
             self.application_name, "PO:", negate_match=True)
 
-    def test_policyd_good_yaml(self):
+    def test_001_policyd_good_yaml(self):
         # Test that the policyd with a good zipped yaml file puts the yaml file
         # in the right directory
         good = {
@@ -151,7 +151,9 @@ class KeystonePolicydTest(PolicydTest,
         super(KeystonePolicydTest, cls).setUpClass(application_name)
 
     def test_disable_service(self):
-        self._set_policy_with({"identity:get_auth_domains": "!"})
+        logging.info("Doing policyd override to disable listing domains")
+        self._set_policy_with(
+            {'rule.yaml': "{'identity:get_auth_domains': '!'}"})
         with self.config_change(
                 {'preferred-api-version': self.default_api_version},
                 {'preferred-api-version': '3'},

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -114,7 +114,10 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         # check that the status includes "PO:" at the beginning of the status
         # line
         app_status = zaza_juju.get_application_status(self.application_name)
-        logging.info("App status is: {}".format(app_status))
+        wl_stats = [v['workload-status']['info']
+                    for k, v in app_status['units'].items()
+                    if k.split('/')[0] == self.application_name]
+        logging.info("App status is: {}".format(wl_stats))
 
         # disable the policy override
         # verify that the file no longer exists

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -37,12 +37,14 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         service: keystone
     """
 
+    @classmethod
     def setUpClass(cls, application_name=None):
         super(PolicydTest, cls).setUpClass(application_name)
         cls._tmp_dir = tempfile.mkdtemp()
         cls._service_name = \
             cls.test_config['tests_options']['policyd']['service']
 
+    @classmethod
     def tearDownClass(cls):
         super(PolicydTest, cls).tearDownClass()
         try:

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -153,7 +153,7 @@ class KeystonePolicydTest(PolicydTest,
     def test_disable_service(self):
         logging.info("Doing policyd override to disable listing domains")
         self._set_policy_with(
-            {'rule.yaml': "{'identity:list_projects': '!'}"})
+            {'rule.yaml': "{'identity:list_services': '!'}"})
 
         # verify (with the config off) that we can actually access
         # these points
@@ -224,9 +224,9 @@ class KeystonePolicydTest(PolicydTest,
                     keystone_client = (
                         openstack_utils.get_keystone_session_client(
                             keystone_session))
-                    keystone_client.projects.list()
+                    keystone_client.services.list()
                     raise zaza_exceptions.PolicydError(
-                        'Retrieve domain list as admin with project scoped '
+                        'Retrieve service list as admin with project scoped '
                         'token passed and should have failed. IP = {}'
                         .format(ip))
                 except keystoneauth1.exceptions.http.Forbidden:

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -166,11 +166,11 @@ class KeystonePolicydTest(PolicydTest,
                     logging.info('keystone IP {}'.format(ip))
                     openrc = {
                         'API_VERSION': 3,
-                        'OS_USERNAME': DEMO_ADMIN_USER,
-                        'OS_PASSWORD': DEMO_ADMIN_USER_PASSWORD,
+                        'OS_USERNAME': ch_keystone.DEMO_ADMIN_USER,
+                        'OS_PASSWORD': ch_keystone.DEMO_ADMIN_USER_PASSWORD,
                         'OS_AUTH_URL': 'http://{}:5000/v3'.format(ip),
-                        'OS_USER_DOMAIN_NAME': DEMO_DOMAIN,
-                        'OS_DOMAIN_NAME': DEMO_DOMAIN,
+                        'OS_USER_DOMAIN_NAME': ch_keystone.DEMO_DOMAIN,
+                        'OS_DOMAIN_NAME': ch_keystone.DEMO_DOMAIN,
                     }
                     if self.tls_rid:
                         openrc['OS_CACERT'] = \

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -124,12 +124,13 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         # disable the policy override
         logging.info("Disabling policy override ...")
         self._set_config_and_wait(False)
+        logging.info("Done setting false?")
         # check that the status no longer has "PO:" on it.
         app_status = zaza_juju.get_application_status(self.application_name)
         wl_stats = [v['workload-status']['info']
                     for k, v in app_status['units'].items()
                     if k.split('/')[0] == self.application_name]
-        logging.info("App status is: {}".format(wl_stats))
+        logging.info("After App status is: {}".format(wl_stats))
         self.assertFalse(any(s.startswith("PO:") for s in wl_stats))
         logging.info("... done")
 

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -129,6 +129,7 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         wl_stats = [v['workload-status']['info']
                     for k, v in app_status['units'].items()
                     if k.split('/')[0] == self.application_name]
+        logging.info("App status is: {}".format(wl_stats))
         self.assertFalse(any(s.startswith("PO:") for s in wl_stats))
         logging.info("... done")
 

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -62,6 +62,7 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         """Ensure that the policyd config is switched off and the charm is
         stable at the end of the test.
         """
+        logging.info("tearDown")
         self._set_config_and_wait(False)
 
     def _set_config_and_wait(self, state):

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -175,12 +175,6 @@ class KeystonePolicydTest(PolicydTest,
                 except keystoneauth1.exceptions.http.Forbidden:
                     logging.info("keystone IP:{} policyd override working"
                                  .format(ip))
-                finally:
-                    return
-                    self._set_config(False)
-                    zaza_model.block_until_wl_status_info_starts_with(
-                        self.application_name, "PO:", negate_match=True)
-                    zaza_model.block_until_all_units_idle()
 
             logging.info('OK')
 

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -176,6 +176,7 @@ class KeystonePolicydTest(PolicydTest,
                     logging.info("keystone IP:{} policyd override working"
                                  .format(ip))
                 finally:
+                    return
                     self._set_config(False)
                     zaza_model.block_until_wl_status_info_starts_with(
                         self.application_name, "PO:", negate_match=True)

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -78,6 +78,7 @@ class PolicydTest(test_utils.OpenStackBaseTest):
         with zipfile.ZipFile(path, "w") as zfp:
             for name, contents in files.items():
                 zfp.writestr(name, contents)
+        return path
 
     def test_policyd_good_yaml(self):
         # Test that the policyd with a good zipped yaml file puts the yaml file

--- a/zaza/openstack/utilities/exceptions.py
+++ b/zaza/openstack/utilities/exceptions.py
@@ -172,3 +172,9 @@ class NovaGuestRestartFailed(Exception):
     """Nova guest restart failed."""
 
     pass
+
+
+class PolicydError(Exception):
+    """Policyd override failed."""
+
+    pass


### PR DESCRIPTION
The policyd tests in zaza are general, in that they will be callable from any `tests.yaml` bundle in a charm without (hopefully) requiring any specialisation other than config keys in the `tests.yaml`.

Add the initial, general, 'success' test for policyd support in charms.

Note that this merge depends on a PR in zaza which should be merged first:
https://github.com/openstack-charmers/zaza/pull/296