### PR TITLE
Increase wait time for guest to boot.

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1981,7 +1981,7 @@ def get_ports_from_device_id(neutron_client, device_id):
 
 
 @tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, max=60),
-                reraise=True, stop=tenacity.stop_after_attempt(8))
+                reraise=True, stop=tenacity.stop_after_attempt(10))
 def cloud_init_complete(nova_client, vm_id, bootstring):
     """Wait for cloud init to complete on the given vm.
 


### PR DESCRIPTION
Zaza seems to currently wait for 64+32+16+8+4+2+1 seconds (127) for
a guest to boot. This is not quite enough sometimes, so increase
this to 511 seconds.