### PR TITLE
Increase cert ttl from 80days to 4000days

### DIFF
--- a/zaza/openstack/utilities/cert.py
+++ b/zaza/openstack/utilities/cert.py
@@ -190,7 +190,7 @@ def sign_csr(csr, ca_private_key, ca_cert=None, issuer_name=None,
         datetime.datetime.today() - datetime.timedelta(1, 0, 0),
     )
     builder = builder.not_valid_after(
-        datetime.datetime.today() + datetime.timedelta(80, 0, 0),
+        datetime.datetime.today() + datetime.timedelta(4000, 0, 0),
     )
     builder = builder.subject_name(new_csr.subject)
     builder = builder.public_key(new_csr.public_key())


### PR DESCRIPTION
Vault testing is failed if we want to
increase vault's default ttl to 10 years
because zaza specify cert's ttl is only 80days.

https://review.opendev.org/#/c/678161