### PR TITLE
Series upgrade tests run funcs after upgrade.

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_generic.py
+++ b/unit_tests/utilities/test_zaza_utilities_generic.py
@@ -287,7 +287,8 @@ class TestGenericUtils(ut_utils.BaseTestCase):
                 mock.call("{}/{}".format(_application, machine_num),
                           machine_num, origin=_origin,
                           from_series=_from_series, to_series=_to_series,
-                          workaround_script=_workaround_script, files=_files),
+                          workaround_script=_workaround_script, files=_files,
+                          post_upgrade_functions=None),
             )
 
         # Pause primary peers and subordinates
@@ -325,7 +326,8 @@ class TestGenericUtils(ut_utils.BaseTestCase):
                 mock.call("{}/{}".format(_application, machine_num),
                           machine_num, origin=_origin,
                           from_series=_from_series, to_series=_to_series,
-                          workaround_script=_workaround_script, files=_files),
+                          workaround_script=_workaround_script, files=_files,
+                          post_upgrade_functions=None),
             )
 
         # Pause subordinates
@@ -356,7 +358,8 @@ class TestGenericUtils(ut_utils.BaseTestCase):
                 mock.call("{}/{}".format(_application, machine_num),
                           machine_num, origin=_origin,
                           from_series=_from_series, to_series=_to_series,
-                          workaround_script=_workaround_script, files=_files),
+                          workaround_script=_workaround_script, files=_files,
+                          post_upgrade_functions=None),
             )
 
         # No Pausiing

--- a/zaza/openstack/charm_tests/series_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/tests.py
@@ -52,6 +52,7 @@ class SeriesUpgradeTest(unittest.TestCase):
             origin = "openstack-origin"
             pause_non_leader_subordinate = True
             pause_non_leader_primary = True
+            post_upgrade_functions = []
             # Skip subordinates
             if applications[application]["subordinate-to"]:
                 continue
@@ -78,6 +79,10 @@ class SeriesUpgradeTest(unittest.TestCase):
                 origin = None
                 pause_non_leader_primary = False
                 pause_non_leader_subordinate = False
+            if "vault" in applications[application]["charm"]:
+                post_upgrade_functions = [
+                    ('zaza.openstack.charm_tests.vault.setup.'
+                     'basic_setup_and_unseal')]
             if ("mongodb" in applications[application]["charm"] or
                     "vault" in applications[application]["charm"]):
                 # Mongodb and vault need to run series upgrade
@@ -86,7 +91,8 @@ class SeriesUpgradeTest(unittest.TestCase):
                     application,
                     from_series=self.from_series,
                     to_series=self.to_series,
-                    completed_machines=completed_machines)
+                    completed_machines=completed_machines,
+                    post_upgrade_functions=post_upgrade_functions)
                 continue
 
             # The rest are likley APIs use defaults
@@ -100,7 +106,8 @@ class SeriesUpgradeTest(unittest.TestCase):
                 origin=origin,
                 completed_machines=completed_machines,
                 workaround_script=self.workaround_script,
-                files=self.files)
+                files=self.files,
+                post_upgrade_functions=post_upgrade_functions)
 
 
 class OpenStackSeriesUpgrade(SeriesUpgradeTest):


### PR DESCRIPTION
Execute a list of functions after series upgrade if one is
supplied. This change is driven by the upgrade testing of vault.
Vault needs to be unsealed after it is rebooted.