### PR TITLE
Do set DNS on overcloud subnets

### DIFF
--- a/zaza/openstack/configure/network.py
+++ b/zaza/openstack/configure/network.py
@@ -172,6 +172,10 @@ def setup_sdn(network_config, keystone_session=None):
         network_config.get("private_net_cidr"),
         subnetpool=subnetpool,
         ip_version=ip_version)
+    openstack_utils.update_subnet_dns(
+        neutron_client,
+        project_subnet,
+        network_config["external_dns"])
     openstack_utils.plug_subnet_into_router(
         neutron_client,
         network_config["router_name"],


### PR DESCRIPTION
It turns out we do need to set DNS on the overcloud subnet. It should be
the .2 of the CIDR under test and not the _admin_net's .2. There seems
there are security group rules in the way.