### PR TITLE
Refactor swift tests and add storage

### DIFF
--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -62,6 +62,8 @@ class SwiftImageCreateTest(test_utils.OpenStackBaseTest):
         self.assertEqual(image['size'], total_bytes)
         openstack_utils.delete_image(self.glance_client, image['id'])
 
+class SwiftProxyTests(test_utils.OpenStackBaseTest):
+
     def test_901_pause_resume(self):
         """Run pause and resume tests.
 
@@ -80,3 +82,27 @@ class SwiftImageCreateTest(test_utils.OpenStackBaseTest):
             'diskusage',
             action_params={})
         self.assertEqual(action.status, "completed")
+
+class SwiftStorageTests(test_utils.OpenStackBaseTest):
+
+    def test_901_pause_resume(self):
+        """Run pause and resume tests.
+
+        Pause service and check services are stopped then resume and check
+        they are started
+        """
+        services = ['swift-account-server',
+                    'swift-account-auditor',
+                    'swift-account-reaper',
+                    'swift-account-replicator',
+                    'swift-container-server',
+                    'swift-container-auditor',
+                    'swift-container-replicator',
+                    'swift-container-updater',
+                    'swift-object-server',
+                    'swift-object-auditor',
+                    'swift-object-replicator',
+                    'swift-object-updater',
+                    'swift-container-sync']
+        with self.pause_resume(services):
+            logging.info("Testing pause resume")

--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -62,7 +62,9 @@ class SwiftImageCreateTest(test_utils.OpenStackBaseTest):
         self.assertEqual(image['size'], total_bytes)
         openstack_utils.delete_image(self.glance_client, image['id'])
 
+
 class SwiftProxyTests(test_utils.OpenStackBaseTest):
+    """Tests specific to swift proxy."""
 
     def test_901_pause_resume(self):
         """Run pause and resume tests.
@@ -83,7 +85,9 @@ class SwiftProxyTests(test_utils.OpenStackBaseTest):
             action_params={})
         self.assertEqual(action.status, "completed")
 
+
 class SwiftStorageTests(test_utils.OpenStackBaseTest):
+    """Tests specific to swift storage."""
 
     def test_901_pause_resume(self):
         """Run pause and resume tests.


### PR DESCRIPTION
The SwiftImageCreateTest was running a pause/resume test for
swift proxy which does not make sense. So, break the proxy specific
tests into their own class and add a class for storage. A
subsequent change to the swift-proxy charm will be needed to add
the new proxy test class to the tests.yaml.