### PR TITLE
Teach `basic_overcloud_network` configure job about OVN

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_juju.py
+++ b/unit_tests/utilities/test_zaza_utilities_juju.py
@@ -101,8 +101,8 @@ class TestJujuUtils(ut_utils.BaseTestCase):
 
         # Machine data
         self.assertEqual(
-            juju_utils.get_machines_for_application(self.application),
-            [self.machine])
+            next(juju_utils.get_machines_for_application(self.application)),
+            self.machine)
         self.get_application_status.assert_called_once()
 
         # Subordinate application has no units
@@ -115,9 +115,9 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.get_application_status.side_effect = _get_application_status
 
         self.assertEqual(
-            juju_utils.get_machines_for_application(
-                self.subordinate_application),
-            [self.machine])
+            next(juju_utils.get_machines_for_application(
+                self.subordinate_application)),
+            self.machine)
 
     def test_get_unit_name_from_host_name(self):
         unit_mock1 = mock.MagicMock()
@@ -151,8 +151,9 @@ class TestJujuUtils(ut_utils.BaseTestCase):
         self.get_machines_for_application.return_value = [self.machine]
 
         self.assertEqual(
-            juju_utils.get_machine_uuids_for_application(self.application),
-            [self.machine_data.get("instance-id")])
+            next(juju_utils.get_machine_uuids_for_application(
+                self.application)),
+            self.machine_data.get("instance-id"))
         self.get_machines_for_application.assert_called_once_with(
             self.application)
 

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -1202,4 +1202,10 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             'neutron-api', 'enable-dvr')
 
     def test_ovn_present(self):
-        pass
+        self.patch_object(openstack_utils.model, 'get_application')
+        self.get_application.side_effect = [None, KeyError]
+        self.assertTrue(openstack_utils.ovn_present())
+        self.get_application.side_effect = [KeyError, None]
+        self.assertTrue(openstack_utils.ovn_present())
+        self.get_application.side_effect = [KeyError, KeyError]
+        self.assertFalse(openstack_utils.ovn_present())

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -160,7 +160,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
 
         # Already exists
         network = openstack_utils.create_external_network(
-            self.neutronclient, self.project_id, False)
+            self.neutronclient, self.project_id)
         self.assertEqual(network, self.network["network"])
         self.neutronclient.create_network.assert_not_called()
 
@@ -170,7 +170,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         network_msg = copy.deepcopy(self.network)
         network_msg["network"].pop("id")
         network = openstack_utils.create_external_network(
-            self.neutronclient, self.project_id, False)
+            self.neutronclient, self.project_id)
         self.assertEqual(network, self.network["network"])
         self.neutronclient.create_network.assert_called_once_with(
             network_msg)
@@ -1194,3 +1194,12 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             mock.call('ovn-chassis'),
             mock.call('ovn-dedicated-chassis'),
         ])
+
+    def test_dvr_enabled(self):
+        self.patch_object(openstack_utils, 'get_application_config_option')
+        openstack_utils.dvr_enabled()
+        self.get_application_config_option.assert_called_once_with(
+            'neutron-api', 'enable-dvr')
+
+    def test_ovn_present(self):
+        pass

--- a/zaza/openstack/charm_tests/neutron/setup.py
+++ b/zaza/openstack/charm_tests/neutron/setup.py
@@ -16,6 +16,8 @@
 
 """Setup for Neutron deployments."""
 
+import functools
+
 from zaza.openstack.configure import (
     network,
 )
@@ -56,12 +58,14 @@ DEFAULT_UNDERCLOUD_NETWORK_CONFIG = {
 }
 
 
-def basic_overcloud_network():
+def basic_overcloud_network(limit_gws=None):
     """Run setup for neutron networking.
 
     Configure the following:
         The overcloud network using subnet pools
 
+    :param limit_gws: Limit the number of gateways that get a port attached
+    :type limit_gws: int
     """
     cli_utils.setup_logging()
 
@@ -81,7 +85,20 @@ def basic_overcloud_network():
     if juju_utils.get_provider_type() == "openstack":
         undercloud_ks_sess = openstack_utils.get_undercloud_keystone_session()
         network.setup_gateway_ext_port(network_config,
-                                       keystone_session=undercloud_ks_sess)
+                                       keystone_session=undercloud_ks_sess,
+                                       limit_gws=None)
 
     # Confugre the overcloud network
     network.setup_sdn(network_config, keystone_session=keystone_session)
+
+
+# Configure function to get one gateway with external network
+overcloud_network_one_gw = functools.partial(
+    basic_overcloud_network,
+    limit_gws=1)
+
+
+# Configure function to get two gateways with external network
+overcloud_network_two_gws = functools.partial(
+    basic_overcloud_network,
+    limit_gws=2)

--- a/zaza/openstack/charm_tests/neutron/setup.py
+++ b/zaza/openstack/charm_tests/neutron/setup.py
@@ -25,7 +25,6 @@ from zaza.openstack.utilities import (
     juju as juju_utils,
     openstack as openstack_utils,
 )
-import zaza.model as model
 
 
 # The overcloud network configuration settings are declared.
@@ -74,10 +73,6 @@ def basic_overcloud_network():
     network_config.update(DEFAULT_UNDERCLOUD_NETWORK_CONFIG)
     # Environment specific settings
     network_config.update(generic_utils.get_undercloud_env_vars())
-    # Deployed model settings
-    if (model.get_application_config('neutron-api')
-            .get('enable-dvr').get('value')):
-        network_config.update({"dvr_enabled": True})
 
     # Get keystone session
     keystone_session = openstack_utils.get_overcloud_keystone_session()

--- a/zaza/openstack/configure/network.py
+++ b/zaza/openstack/configure/network.py
@@ -183,7 +183,8 @@ def setup_sdn(network_config, keystone_session=None):
     openstack_utils.add_neutron_secgroup_rules(neutron_client, project_id)
 
 
-def setup_gateway_ext_port(network_config, keystone_session=None):
+def setup_gateway_ext_port(network_config, keystone_session=None,
+                           limit_gws=None):
     """Perform setup external port on Neutron Gateway.
 
     For OpenStack on OpenStack scenarios.
@@ -192,6 +193,8 @@ def setup_gateway_ext_port(network_config, keystone_session=None):
     :type network_config: dict
     :param keystone_session: Keystone session object for undercloud
     :type keystone_session: keystoneauth1.session.Session object
+    :param limit_gws: Limit the number of gateways that get a port attached
+    :type limit_gws: Optional[int]
     :returns: None
     :rtype: None
     """
@@ -226,7 +229,8 @@ def setup_gateway_ext_port(network_config, keystone_session=None):
         nova_client,
         neutron_client,
         net_id=net_id,
-        add_dataport_to_netplan=add_dataport_to_netplan)
+        add_dataport_to_netplan=add_dataport_to_netplan,
+        limit_gws=limit_gws)
 
 
 def run_from_cli(**kwargs):

--- a/zaza/openstack/configure/network.py
+++ b/zaza/openstack/configure/network.py
@@ -129,7 +129,6 @@ def setup_sdn(network_config, keystone_session=None):
     ext_network = openstack_utils.create_external_network(
         neutron_client,
         project_id,
-        network_config.get("dvr_enabled", False),
         network_config["external_net_name"])
     openstack_utils.create_external_subnet(
         neutron_client,
@@ -226,7 +225,6 @@ def setup_gateway_ext_port(network_config, keystone_session=None):
     openstack_utils.configure_gateway_ext_port(
         nova_client,
         neutron_client,
-        dvr_mode=network_config.get("dvr_enabled", False),
         net_id=net_id,
         add_dataport_to_netplan=add_dataport_to_netplan)
 

--- a/zaza/openstack/utilities/juju.py
+++ b/zaza/openstack/utilities/juju.py
@@ -85,6 +85,8 @@ def get_machines_for_application(application):
     :rtype: Iterator[str]
     """
     status = get_application_status(application)
+    if not status:
+        raise StopIteration
 
     # libjuju juju status no longer has units for subordinate charms
     # Use the application it is subordinate-to to find machines

--- a/zaza/openstack/utilities/juju.py
+++ b/zaza/openstack/utilities/juju.py
@@ -81,21 +81,18 @@ def get_machines_for_application(application):
 
     :param application: Application name
     :type application: string
-    :returns: List of machines for an application
-    :rtype: list
+    :returns: machines for an application
+    :rtype: Iterator[str]
     """
     status = get_application_status(application)
 
     # libjuju juju status no longer has units for subordinate charms
     # Use the application it is subordinate-to to find machines
     if status.get("units") is None and status.get("subordinate-to"):
-        return get_machines_for_application(status.get("subordinate-to")[0])
+        status = get_application_status(status.get("subordinate-to")[0])
 
-    machines = []
     for unit in status.get("units").keys():
-        machines.append(
-            status.get("units").get(unit).get("machine"))
-    return machines
+        yield status.get("units").get(unit).get("machine")
 
 
 def get_unit_name_from_host_name(host_name, application):
@@ -151,13 +148,11 @@ def get_machine_uuids_for_application(application):
 
     :param application: Application name
     :type application: string
-    :returns: List of machine uuuids for an application
-    :rtype: list
+    :returns: machine uuuids for an application
+    :rtype: Iterator[str]
     """
-    uuids = []
     for machine in get_machines_for_application(application):
-        uuids.append(get_machine_status(machine, key="instance-id"))
-    return uuids
+        yield get_machine_status(machine, key="instance-id")
 
 
 def get_provider_type():

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -477,15 +477,14 @@ def ovn_present():
     :returns: True when OVN is present, False otherwise
     :rtype: bool
     """
-    try:
-        for name in ('ovn-chassis', 'ovn-dedicated-chassis'):
+    app_presence = []
+    for name in ('ovn-chassis', 'ovn-dedicated-chassis'):
+        try:
             model.get_application(name)
-            return True
-    except KeyError:
-        return False
-    else:
-        raise RuntimeError('Unable to determine whether or not OVN is present '
-                           'in deployment')
+            app_presence.append(True)
+        except KeyError:
+            app_presence.append(False)
+    return any(app_presence)
 
 
 BRIDGE_MAPPINGS = 'bridge-mappings'


### PR DESCRIPTION
For reference I have successful runs of existing jobs with the new code, both classic gateway topologies [0][1] and DVR topologies [2]. And of course a successful run with OVN [3].

A note about [2], the bionic-train job appears to fail both with and without this change atm, the referenced log still shows 10+ successful run with a mix of classic gateway/DVR topologies.

0: https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_smoke/openstack/charm-neutron-dynamic-routing/692560/1/13408/index.html
1: https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_smoke/openstack/charm-nova-cell-controller/692561/1/13409/index.html
2: https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_full/openstack/charm-neutron-api/692562/1/4225/index.html
3: https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_full/x/charm-ovn-chassis/692514/1/4219/index.html