### PR TITLE
Make non-existent tests/tests.yaml non-fatal where possible

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -344,7 +344,7 @@ class PerconaClusterColdStartTest(PerconaClusterTest):
         logging.debug("Wait for application states ...")
         for unit in zaza.model.get_units(self.application):
             zaza.model.run_on_unit(unit.entity_id, "hooks/update-status")
-        test_config = lifecycle_utils.get_charm_config()
+        test_config = lifecycle_utils.get_charm_config(fatal=False)
         zaza.model.wait_for_application_states(
             states=test_config.get("target_deploy_status", {}))
 

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -98,7 +98,7 @@ class OpenStackBaseTest(unittest.TestCase):
         """Run setup for test class to create common resourcea."""
         cls.keystone_session = openstack_utils.get_overcloud_keystone_session()
         cls.model_name = model.get_juju_model()
-        cls.test_config = lifecycle_utils.get_charm_config()
+        cls.test_config = lifecycle_utils.get_charm_config(fatal=False)
         if application_name:
             cls.application_name = application_name
         else:

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -84,7 +84,7 @@ def auto_initialize(cacert=None, validation_application='keystone'):
         allowed_domains='openstack.local')
 
     zaza.model.wait_for_agent_status()
-    test_config = lifecycle_utils.get_charm_config()
+    test_config = lifecycle_utils.get_charm_config(fatal=False)
     zaza.model.wait_for_application_states(
         states=test_config.get('target_deploy_status', {}))
 

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -713,7 +713,7 @@ def configure_gateway_ext_port(novaclient, neutronclient, net_id=None,
                 application_name,
                 configuration=config)
         zaza.model.wait_for_agent_status()
-        test_config = zaza.charm_lifecycle.utils.get_charm_config()
+        test_config = zaza.charm_lifecycle.utils.get_charm_config(fatal=False)
         zaza.model.wait_for_application_states(
             states=test_config.get('target_deploy_status', {}))
 


### PR DESCRIPTION
Not all test environments or runners are equal, don't crash on
non-existent test config.