### PR TITLE
Add functional tests for Manila with Ganesha

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ python-cinderclient
 python-glanceclient
 python-heatclient
 python-keystoneclient
+python-manilaclient
 python-neutronclient
 python-novaclient
 python-octaviaclient

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_require = [
     'python-heatclient',
     'python-glanceclient',
     'python-keystoneclient',
+    'python-manilaclient',
     'python-novaclient',
     'python-neutronclient',
     'python-octaviaclient',

--- a/zaza/openstack/charm_tests/manila_ganesha/__init__.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Encapsulate Manila Ganesha setup and testing."""

--- a/zaza/openstack/charm_tests/manila_ganesha/setup.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/setup.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Encapsulate Manila Ganesha setup."""
+
+
+import zaza.openstack.utilities.openstack as openstack_utils
+
+from manilaclient import client as manilaclient
+
+
+def setup_ganesha_share_type(manila_client=None):
+    """Create a share type for manila with Ganesha.
+
+    :param manila_client: Authenticated manilaclient
+    :type manila_client: manilaclient.Client
+    """
+    if manila_client is None:
+        keystone_session = openstack_utils.get_overcloud_keystone_session()
+        manila_client = manilaclient.Client(
+            session=keystone_session, client_version='2')
+
+    manila_client.share_types.create(
+        name="cephfsnfstype", spec_driver_handles_share_servers=False,
+        extra_specs={
+            'vendor_name': 'Ceph',
+            'storage_protocol': 'NFS',
+            'snapshot_support': False,
+        })

--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -63,7 +63,6 @@ write_files:
         share = self.manila_client.shares.create(
             share_type='cephfsnfstype', name='cephnfsshare1',
             share_proto="nfs", size=1)
-        mount_path = share.export_locations[0]
 
         # Spawn Servers
         instance_1 = guest.launch_instance(
@@ -90,6 +89,8 @@ write_files:
         def verify_setup(stdin, stdout, stderr):
             status = stdout.channel.recv_exit_status()
             self.assertEqual(status, 0)
+
+        mount_path = share.export_locations[0]
 
         openstack_utils.ssh_command(
             'sudo mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph && '

--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate Manila Ganesha testing."""
+
+
+from manilaclient import client as manilaclient
+
+import zaza.openstack.charm_tests.glance.setup as glance_setup
+import zaza.openstack.charm_tests.neutron.tests as neutron_tests
+import zaza.openstack.charm_tests.nova.utils as nova_utils
+import zaza.openstack.charm_tests.test_utils as test_utils
+import zaza.openstack.configure.guest as guest
+import zaza.openstack.utilities.openstack as openstack_utils
+
+
+class ManilaGaneshaTests(test_utils.OpenStackBaseTest):
+    """Encapsulate Manila Ganesha tests."""
+
+    RESOURCE_PREFIX = 'zaza-manilatests'
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running tests."""
+        super(ManilaGaneshaTests, cls).setUpClass()
+        cls.nova_client = (
+            openstack_utils.get_nova_session_client(cls.keystone_session))
+        cls.manila_client = manilaclient.Client(
+            session=cls.keystone_session, client_version='2')
+
+    def test_manila_share(self):
+        """Test that Manila + Ganesha shares can be accessed on two instances.
+
+        1. create a share
+        2. Spawn two servers
+        3. mount it on both
+        4. write a file on one
+        5. read it on the other
+        6. profit
+        """
+        # Create a share
+        share = self.manila_client.shares.create(
+            share_type='cephfsnfstype', name='cephnfsshare1',
+            share_proto="nfs", size=1)
+
+        # Spawn Servers
+        guest.launch_instance(
+            glance_setup.LTS_IMAGE_NAME,
+            vm_name='{}-ins-1'.format(self.RESOURCE_PREFIX))
+        guest.launch_instance(
+            glance_setup.LTS_IMAGE_NAME,
+            vm_name='{}-ins-2'.format(self.RESOURCE_PREFIX))
+
+        instance_1 = self.nova_client.servers.find(
+            name='{}-ins-1'.format(self.RESOURCE_PREFIX))
+        fip_1 = neutron_tests.floating_ips_from_instance(instance_1)[0]
+        instance_2 = self.nova_client.servers.find(
+            name='{}-ins-2'.format(self.RESOURCE_PREFIX))
+        fip_2 = neutron_tests.floating_ips_from_instance(instance_2)[0]
+
+        share.allow(access_type='ip', access=fip_1, access_level='rw')
+        share.allow(access_type='ip', access=fip_2, access_level='rw')
+
+        # Mount Share
+        username = guest.boot_tests['bionic']['username']
+        password = guest.boot_tests['bionic'].get('password')
+        privkey = openstack_utils.get_private_key(nova_utils.KEYPAIR_NAME)
+        mount_path = share.export_locations[0]
+
+        # Write a file on instance_1
+        def verify_setup(stdin, stdout, stderr):
+            status = stdout.channel.recv_exit_status()
+            self.assertEqual(status, 0)
+
+        openstack_utils.ssh_command(
+            username, fip_1, 'instance-1',
+            'sudo apt install -yq nfs-common && '
+            'sudo mkdir -p /mnt/ceph && '
+            'sudo mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph && '
+            'echo "test" | sudo tee /mnt/ceph/test'.format(
+                mount_path),
+            password=password, privkey=privkey, verify=verify_setup)
+
+        # Read that file on instance_2
+        openstack_utils.ssh_command(
+            username, fip_2, 'instance-2',
+            'sudo apt install -yq nfs-common && '
+            'sudo /bin/mkdir -p /mnt/ceph && '
+            'sudo /bin/mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph'
+            .format(mount_path),
+            password=password, privkey=privkey, verify=verify_setup)
+
+        def verify(stdin, stdout, stderr):
+            status = stdout.channel.recv_exit_status()
+            out = ""
+            print("[{}] Stdout:".format(status))
+            for line in iter(stdout.readline, ""):
+                out += line
+            self.assertEqual(out, "test\n")
+
+        openstack_utils.ssh_command(
+            username, fip_2, 'instance-2',
+            'sudo cat /mnt/ceph/test'.format(
+                mount_path),
+            password=password, privkey=privkey, verify=verify)

--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -93,6 +93,7 @@ write_files:
         mount_path = share.export_locations[0]
 
         openstack_utils.ssh_command(
+            username, fip_1, 'instance-1',
             'sudo mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph && '
             'echo "test" | sudo tee /mnt/ceph/test'.format(
                 mount_path),
@@ -100,6 +101,7 @@ write_files:
 
         # Read that file on instance_2
         openstack_utils.ssh_command(
+            username, fip_2, 'instance-2',
             'sudo /bin/mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph'
             .format(mount_path),
             password=password, privkey=privkey, verify=verify_setup)

--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -34,10 +34,6 @@ class ManilaGaneshaTests(test_utils.OpenStackBaseTest):
     INSTANCE_USERDATA = """#cloud-config
 packages:
 - nfs-common
-write_files:
-- path: "/mnt/ceph"
-  permissions: '0600'
-  owner: root:root
 """
 
     @classmethod
@@ -94,6 +90,7 @@ write_files:
 
         openstack_utils.ssh_command(
             username, fip_1, 'instance-1',
+            'sudo mkdir -p /mnt/ceph && '
             'sudo mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph && '
             'echo "test" | sudo tee /mnt/ceph/test'.format(
                 mount_path),
@@ -102,6 +99,7 @@ write_files:
         # Read that file on instance_2
         openstack_utils.ssh_command(
             username, fip_2, 'instance-2',
+            'sudo mkdir -p /mnt/ceph && '
             'sudo /bin/mount -t nfs -o nfsvers=4.1,proto=tcp {} /mnt/ceph'
             .format(mount_path),
             password=password, privkey=privkey, verify=verify_setup)

--- a/zaza/openstack/configure/guest.py
+++ b/zaza/openstack/configure/guest.py
@@ -62,6 +62,8 @@ def launch_instance(instance_key, use_boot_volume=False, vm_name=None,
     :type meta: dict
     :param userdata: Configuration to use upon launch, used by cloud-init.
     :type userdata: str
+    :returns: the created instance
+    :rtype: novaclient.Server
     """
     keystone_session = openstack_utils.get_overcloud_keystone_session()
     nova_client = openstack_utils.get_nova_session_client(keystone_session)
@@ -140,3 +142,4 @@ def launch_instance(instance_key, use_boot_volume=False, vm_name=None,
         vm_name=vm_name,
         password=boot_tests[instance_key].get('password'),
         privkey=openstack_utils.get_private_key(nova_utils.KEYPAIR_NAME))
+    return instance


### PR DESCRIPTION
Add a functional gate where we mount a share on two VMs
in the cloud under test to validate that manila + ganesha
shares work correctly.