### PR TITLE
Add octavia policyd tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-
 aiounittest
 async_generator
 juju
 juju_wait
-PyYAML<=4.2,>=3.0 
+PyYAML<=4.2,>=3.0
 flake8>=2.2.4,<=3.5.0
 flake8-docstrings
 flake8-per-file-ignores
@@ -35,6 +34,7 @@ python-swiftclient
 tenacity
 distro-info
 paramiko
+
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -644,7 +644,7 @@ class HeatTests(BasePolicydSpecialization):
 class OctaviaTests(BasePolicydSpecialization):
     """Test the policyd override using the octavia client."""
 
-    _rule = "{'os_load-balancer_api:loadbalancer:get_one': '!'}"
+    _rule = {'rule.yaml': "{'os_load-balancer_api:loadbalancer:get_one': '!'}"}
 
     @classmethod
     def setUpClass(cls, application_name=None):


### PR DESCRIPTION
Providing a policy.d test for Octavia is a bit more complicated as the
obvious policy is just to prevent listing of load balancers;
unfortunately it doesn't work in the upstream, as the code doesn't check
the policy in octavia.  However, "showing" an load balancer does involve
a policy check and so the test is more complicated than 'normal' policy
tests in that a resource is created, then the policy override is checked
and then the resource is deleted.