### PR TITLE
policyd: await agent status executing after config change

### DIFF
--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -86,6 +86,7 @@ class PolicydTest(object):
         config = {"use-policyd-override": s}
         logging.info("Setting config to {}".format(config))
         zaza_model.set_application_config(self.application_name, config)
+        zaza_model.wait_for_agent_status()
 
     def _make_zip_file_from(self, name, files):
         """Make a zip file from a dictionary of filename: string.


### PR DESCRIPTION
The current implementation may miss waiting for config change to
actually happen as it in some circumstances jumps to waiting for a
idle state prior to the model executing anything.

Add a wait for agent status `executing` immediatelly after config
change to avoid this.

Fixes #123