### PR TITLE
First set of updates to set model name explicitly

### DIFF
--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -85,21 +85,23 @@ def get_unit_hostnames(units):
     return host_names
 
 
-def get_pkg_version(application, pkg):
+def get_pkg_version(application, pkg, model_name=None):
     """Return package version.
 
     :param application: Application name
     :type application: string
     :param pkg: Package name
     :type pkg: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: List of package version
     :rtype: list
     """
     versions = []
-    units = model.get_units(application)
+    units = model.get_units(application, model_name=model_name)
     for unit in units:
         cmd = 'dpkg -l | grep {}'.format(pkg)
-        out = juju_utils.remote_run(unit.entity_id, cmd)
+        out = juju_utils.remote_run(unit.entity_id, cmd, model_name=model_name)
         versions.append(out.split('\n')[0].split()[2])
     if len(set(versions)) != 1:
         raise Exception('Unexpected output from pkg version check')

--- a/zaza/openstack/utilities/juju.py
+++ b/zaza/openstack/utilities/juju.py
@@ -25,13 +25,15 @@ from zaza import (
 from zaza.openstack.utilities import generic as generic_utils
 
 
-def get_application_status(application=None, unit=None):
+def get_application_status(application=None, unit=None, model_name=None):
     """Return the juju status for an application.
 
     :param application: Application name
     :type application: string
     :param unit: Specific unit
     :type unit: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: Juju status output for an application
     :rtype: dict
     """
@@ -66,95 +68,112 @@ def get_cloud_configs(cloud=None):
         return generic_utils.get_yaml_config(cloud_config)
 
 
-def get_full_juju_status():
+def get_full_juju_status(model_name=None):
     """Return the full juju status output.
 
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: Full juju status output
     :rtype: dict
     """
-    status = model.get_status()
+    status = model.get_status(model_name=model_name)
     return status
 
 
-def get_machines_for_application(application):
+def get_machines_for_application(application, model_name=None):
     """Return machines for a given application.
 
     :param application: Application name
     :type application: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: machines for an application
     :rtype: Iterator[str]
     """
-    status = get_application_status(application)
+    status = get_application_status(application, model_name=model_name)
     if not status:
         raise StopIteration
 
     # libjuju juju status no longer has units for subordinate charms
     # Use the application it is subordinate-to to find machines
     if status.get("units") is None and status.get("subordinate-to"):
-        status = get_application_status(status.get("subordinate-to")[0])
+        status = get_application_status(status.get("subordinate-to")[0],
+                                        model_name=model_name)
 
     for unit in status.get("units").keys():
         yield status.get("units").get(unit).get("machine")
 
 
-def get_unit_name_from_host_name(host_name, application):
+def get_unit_name_from_host_name(host_name, application, model_name=None):
     """Return the juju unit name corresponding to a hostname.
 
     :param host_name: Host name to map to unit name.
     :type host_name: string
     :param application: Application name
     :type application: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     """
     # Assume that a juju managed hostname always ends in the machine number.
     machine_number = host_name.split('-')[-1]
     unit_names = [
         u.entity_id
-        for u in model.get_units(application_name=application)
+        for u in model.get_units(application_name=application,
+                                 model_name=model_name)
         if int(u.data['machine-id']) == int(machine_number)]
     return unit_names[0]
 
 
-def get_machine_status(machine, key=None):
+def get_machine_status(machine, key=None, model_name=None):
     """Return the juju status for a machine.
 
     :param machine: Machine number
     :type machine: string
     :param key: Key option requested
     :type key: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: Juju status output for a machine
     :rtype: dict
     """
-    status = get_full_juju_status()
+    status = get_full_juju_status(model_name=model_name)
     status = status.machines.get(machine)
     if key:
         status = status.get(key)
     return status
 
 
-def get_machine_series(machine):
+def get_machine_series(machine, model_name=None):
     """Return the juju series for a machine.
 
     :param machine: Machine number
     :type machine: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: Juju series
     :rtype: string
     """
     return get_machine_status(
         machine=machine,
-        key='series'
+        key='series',
+        model_name=model_name
     )
 
 
-def get_machine_uuids_for_application(application):
+def get_machine_uuids_for_application(application, model_name=None):
     """Return machine uuids for a given application.
 
     :param application: Application name
     :type application: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: machine uuuids for an application
     :rtype: Iterator[str]
     """
-    for machine in get_machines_for_application(application):
-        yield get_machine_status(machine, key="instance-id")
+    for machine in get_machines_for_application(application,
+                                                model_name=model_name):
+        yield get_machine_status(machine, key="instance-id",
+                                 model_name=model_name)
 
 
 def get_provider_type():
@@ -175,7 +194,7 @@ def get_provider_type():
         return "openstack"
 
 
-def remote_run(unit, remote_cmd, timeout=None, fatal=None):
+def remote_run(unit, remote_cmd, timeout=None, fatal=None, model_name=None):
     """Run command on unit and return the output.
 
     NOTE: This function is pre-deprecated. As soon as libjuju unit.run is able
@@ -187,13 +206,19 @@ def remote_run(unit, remote_cmd, timeout=None, fatal=None):
     :type arg: int
     :param fatal: Command failure condidered fatal or not
     :type fatal: boolean
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: Juju run output
     :rtype: string
     :raises: model.CommandRunFailed
     """
     if fatal is None:
         fatal = True
-    result = model.run_on_unit(unit, remote_cmd, timeout=timeout)
+    result = model.run_on_unit(
+        unit,
+        remote_cmd,
+        timeout=timeout,
+        model_name=model_name)
     if result:
         if int(result.get("Code")) == 0:
             return result.get("Stdout")
@@ -203,7 +228,7 @@ def remote_run(unit, remote_cmd, timeout=None, fatal=None):
             return result.get("Stderr")
 
 
-def _get_unit_names(names):
+def _get_unit_names(names, model_name=None):
     """Resolve given application names to first unit name of said application.
 
     Helper function that resolves application names to first unit name of
@@ -211,6 +236,8 @@ def _get_unit_names(names):
 
     :param names: List of units/applications to translate
     :type names: list(str)
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: List of units
     :rtype: list(str)
     """
@@ -219,11 +246,14 @@ def _get_unit_names(names):
         if '/' in name:
             result.append(name)
         else:
-            result.append(model.get_first_unit_name(name))
+            result.append(model.get_first_unit_name(
+                name,
+                model_name=model_name))
     return result
 
 
-def get_relation_from_unit(entity, remote_entity, remote_interface_name):
+def get_relation_from_unit(entity, remote_entity, remote_interface_name,
+                           model_name=None):
     """Get relation data passed between two units.
 
     Get relation data for relation with `remote_interface_name` between
@@ -240,6 +270,8 @@ def get_relation_from_unit(entity, remote_entity, remote_interface_name):
     :param remote_interface_name: Name of interface to query on remote end of
                                   relation
     :type remote_interface_name: str
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: dict with relation data
     :rtype: dict
     :raises: model.CommandRunFailed
@@ -247,27 +279,34 @@ def get_relation_from_unit(entity, remote_entity, remote_interface_name):
     application = entity.split('/')[0]
     remote_application = remote_entity.split('/')[0]
     rid = model.get_relation_id(application, remote_application,
-                                remote_interface_name=remote_interface_name)
-    (unit, remote_unit) = _get_unit_names([entity, remote_entity])
+                                remote_interface_name=remote_interface_name,
+                                model_name=model_name)
+    (unit, remote_unit) = _get_unit_names(
+        [entity, remote_entity],
+        model_name=model_name)
     cmd = 'relation-get --format=yaml -r "{}" - "{}"' .format(rid, remote_unit)
-    result = model.run_on_unit(unit, cmd)
+    result = model.run_on_unit(unit, cmd, model_name=model_name)
     if result and int(result.get('Code')) == 0:
         return yaml.safe_load(result.get('Stdout'))
     else:
         raise model.CommandRunFailed(cmd, result)
 
 
-def leader_get(application, key=''):
+def leader_get(application, key='', model_name=None):
     """Get leader settings from leader unit of named application.
 
     :param application: Application to get leader settings from.
     :type application: str
+    :param key: Key option requested
+    :type key: string
+    :param model_name: Name of model to query.
+    :type model_name: str
     :returns: dict with leader settings
     :rtype: dict
     :raises: model.CommandRunFailed
     """
     cmd = 'leader-get --format=yaml {}'.format(key)
-    result = model.run_on_leader(application, cmd)
+    result = model.run_on_leader(application, cmd, model_name=model_name)
     if result and int(result.get('Code')) == 0:
         return yaml.safe_load(result.get('Stdout'))
     else:


### PR DESCRIPTION
Tests which act on multiple models need to be able to specify which model to work with. All methods in zaza.model take a model_name parameter (if they operate against a model). This change starts the process of ensuring that zaza.openstack methods also allow the caller to specify the model name.