### PR TITLE
py3.7+ StopIteration handling

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -816,7 +816,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         _machine = mock.MagicMock()
 
         # No machine returned
-        self._get_machines.side_effect = KeyError
+        self._get_machines.return_value = []
         with self.assertRaises(exceptions.ApplicationNotFound):
             openstack_utils.get_current_os_release_pair()
         self._get_machines.side_effect = None

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -15,7 +15,6 @@
 import copy
 import datetime
 import io
-import itertools
 import mock
 import tenacity
 
@@ -814,14 +813,16 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             name='_get_machine_series'
         )
 
+        _machine = mock.MagicMock()
+
         # No machine returned
-        self._get_machines.side_effect = StopIteration
+        self._get_machines.side_effect = KeyError
         with self.assertRaises(exceptions.ApplicationNotFound):
             openstack_utils.get_current_os_release_pair()
         self._get_machines.side_effect = None
 
         # No series returned
-        self._get_machines.return_value = itertools.repeat('6')
+        self._get_machines.return_value = [_machine]
         self._get_machine_series.return_value = None
         with self.assertRaises(exceptions.SeriesNotFound):
             openstack_utils.get_current_os_release_pair()

--- a/zaza/openstack/utilities/juju.py
+++ b/zaza/openstack/utilities/juju.py
@@ -92,7 +92,7 @@ def get_machines_for_application(application, model_name=None):
     """
     status = get_application_status(application, model_name=model_name)
     if not status:
-        raise StopIteration
+        return
 
     # libjuju juju status no longer has units for subordinate charms
     # Use the application it is subordinate-to to find machines

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1450,7 +1450,7 @@ def get_current_os_release_pair(application='keystone'):
     :raises: exceptions.OSVersionNotFound
     """
     try:
-        machine = juju_utils.get_machines_for_application(application)
+        machine = list(juju_utils.get_machines_for_application(application))[0]
     except KeyError:
         raise exceptions.ApplicationNotFound(application)
 

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1451,7 +1451,7 @@ def get_current_os_release_pair(application='keystone'):
     """
     try:
         machine = list(juju_utils.get_machines_for_application(application))[0]
-    except KeyError:
+    except IndexError:
         raise exceptions.ApplicationNotFound(application)
 
     series = juju_utils.get_machine_series(machine)

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -649,9 +649,9 @@ def configure_gateway_ext_port(novaclient, neutronclient, net_id=None,
         application_names = ['neutron-openvswitch']
         try:
             ngw = 'neutron-gateway'
-            next(juju_utils.get_machine_uuids_for_application(ngw))
+            model.get_application(ngw)
             application_names.append(ngw)
-        except StopIteration:
+        except KeyError:
             # neutron-gateway not in deployment
             pass
     elif ovn_present():
@@ -659,9 +659,9 @@ def configure_gateway_ext_port(novaclient, neutronclient, net_id=None,
         application_names = ['ovn-chassis']
         try:
             ovn_dc_name = 'ovn-dedicated-chassis'
-            next(juju_utils.get_machine_uuids_for_application(ovn_dc_name))
+            model.get_application(ngw)
             application_names.append(ovn_dc_name)
-        except StopIteration:
+        except KeyError:
             # ovn-dedicated-chassis not in deployment
             pass
         port_config_key = 'interface-bridge-mappings'
@@ -1450,8 +1450,8 @@ def get_current_os_release_pair(application='keystone'):
     :raises: exceptions.OSVersionNotFound
     """
     try:
-        machine = next(juju_utils.get_machines_for_application(application))
-    except StopIteration:
+        machine = juju_utils.get_machines_for_application(application)
+    except KeyError:
         raise exceptions.ApplicationNotFound(application)
 
     series = juju_utils.get_machine_series(machine)

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -659,7 +659,7 @@ def configure_gateway_ext_port(novaclient, neutronclient, net_id=None,
         application_names = ['ovn-chassis']
         try:
             ovn_dc_name = 'ovn-dedicated-chassis'
-            model.get_application(ngw)
+            model.get_application(ovn_dc_name)
             application_names.append(ovn_dc_name)
         except KeyError:
             # ovn-dedicated-chassis not in deployment

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -674,35 +674,32 @@ def configure_gateway_ext_port(novaclient, neutronclient, net_id=None,
     if not net_id:
         net_id = get_admin_net(neutronclient)['id']
 
-    try:
-        for uuid in uuids:
-            server = novaclient.servers.get(uuid)
-            ext_port_name = "{}_ext-port".format(server.name)
-            for port in neutronclient.list_ports(device_id=server.id)['ports']:
-                if port['name'] == ext_port_name:
-                    logging.warning(
-                        'Neutron Gateway already has additional port')
-                    break
-            else:
-                logging.info('Attaching additional port to instance, '
-                             'connected to net id: {}'.format(net_id))
-                body_value = {
-                    "port": {
-                        "admin_state_up": True,
-                        "name": ext_port_name,
-                        "network_id": net_id,
-                        "port_security_enabled": False,
-                    }
+    for uuid in uuids:
+        server = novaclient.servers.get(uuid)
+        ext_port_name = "{}_ext-port".format(server.name)
+        for port in neutronclient.list_ports(device_id=server.id)['ports']:
+            if port['name'] == ext_port_name:
+                logging.warning(
+                    'Neutron Gateway already has additional port')
+                break
+        else:
+            logging.info('Attaching additional port to instance, '
+                         'connected to net id: {}'.format(net_id))
+            body_value = {
+                "port": {
+                    "admin_state_up": True,
+                    "name": ext_port_name,
+                    "network_id": net_id,
+                    "port_security_enabled": False,
                 }
-                port = neutronclient.create_port(body=body_value)
-                server.interface_attach(port_id=port['port']['id'],
-                                        net_id=None, fixed_ip=None)
-                if add_dataport_to_netplan:
-                    mac_address = get_mac_from_port(port, neutronclient)
-                    add_interface_to_netplan(server.name,
-                                             mac_address=mac_address)
-    except StopIteration:
-        pass
+            }
+            port = neutronclient.create_port(body=body_value)
+            server.interface_attach(port_id=port['port']['id'],
+                                    net_id=None, fixed_ip=None)
+            if add_dataport_to_netplan:
+                mac_address = get_mac_from_port(port, neutronclient)
+                add_interface_to_netplan(server.name,
+                                         mac_address=mac_address)
     ext_br_macs = []
     for port in neutronclient.list_ports(network_id=net_id)['ports']:
         if 'ext-port' in port['name']:


### PR DESCRIPTION
In python 3.7 StopIteration is no longer an acceptable way to end generation pre-maturely. RuntimeError is now thrown. In other circumstances, StopIteration can be thrown when not expected.

This change re-arranges some code that relied on the old behavior. It should be backward and forward compatible.

[0] https://www.python.org/dev/peps/pep-0479/