### PR TITLE
Allow us to retry the Manila client connection

### DIFF
--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -16,6 +16,7 @@
 
 """Encapsulate Manila testing."""
 
+from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 from manilaclient import client as manilaclient
 
@@ -38,4 +39,7 @@ class ManilaTests(test_utils.OpenStackBaseTest):
     def test_manila_api(self):
         """Test that the Manila API is working."""
         # now just try a list the shares
-        self.manila_client.shares.list()
+        for attempt in Retrying(
+                stop=stop_after_attempt(3),
+                wait=wait_exponential(multiplier=1, min=2, max=10)):
+            self.manila_client.shares.list()


### PR DESCRIPTION
It is possible that Manila looks ready before it is,
so we should retry a bit to ensure that the APi service
is really down before giving up