### PR TITLE
octavia: Conditionally use DVR specific flags

### DIFF
--- a/zaza/openstack/charm_tests/octavia/setup.py
+++ b/zaza/openstack/charm_tests/octavia/setup.py
@@ -137,6 +137,9 @@ def centralized_fip_network():
     4: https://review.opendev.org/#/c/437986/
     5: https://review.opendev.org/#/c/466434/
     """
+    if not openstack.dvr_enabled():
+        logging.info('DVR not enabled, skip.')
+        return
     keystone_session = openstack.get_overcloud_keystone_session()
     neutron_client = openstack.get_neutron_session_client(
         keystone_session)

--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -61,10 +61,13 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
             payload_ips.append(server.networks['private'][0])
         self.assertTrue(len(payload_ips) > 0)
 
-        resp = neutron_client.list_networks(name='private_lb_fip_network')
-        vip_subnet_id = resp['networks'][0]['subnets'][0]
         resp = neutron_client.list_networks(name='private')
         subnet_id = resp['networks'][0]['subnets'][0]
+        if openstack_utils.dvr_enabled():
+            resp = neutron_client.list_networks(name='private_lb_fip_network')
+            vip_subnet_id = resp['networks'][0]['subnets'][0]
+        else:
+            vip_subnet_id = subnet_id
         octavia_client = openstack_utils.get_octavia_session_client(
             keystone_session)
         result = octavia_client.load_balancer_create(


### PR DESCRIPTION
The current test code for octavia requires DVR extensions to be
present on the Neutron API server.

We need to conditionally enable this based on enabled extensions to
allow the test to operate on multiple deployment configurations.