### PR TITLE
Fix hacluster pause/resume tests

### DIFF
--- a/zaza/openstack/charm_tests/hacluster/tests.py
+++ b/zaza/openstack/charm_tests/hacluster/tests.py
@@ -86,11 +86,13 @@ class HaclusterTest(test_utils.OpenStackBaseTest):
             for subordinate in primary_status["units"][leader]["subordinates"]:
                 logging.info("Pausing {}".format(subordinate))
                 zaza.model.run_action(subordinate, "pause")
-                zaza.model.block_until_unit_wl_status(leader, "blocked")
+                zaza.model.block_until_unit_wl_status(
+                    subordinate,
+                    "maintenance")
 
                 logging.info("Resuming {}".format(subordinate))
                 zaza.model.run_action(subordinate, "resume")
-                zaza.model.block_until_unit_wl_status(leader, "active")
+                zaza.model.block_until_unit_wl_status(subordinate, "active")
 
         _states = {"hacluster": {
             "workload-status": "active",


### PR DESCRIPTION
The hacluster tests used to pause the hacluster subordinate but
then rely on the unintended side-effect of the prinicple going
into a blocked state to confirm the action was complete. This is
not what the old amulet tests used to do. Also, more importantly,
the side-effect has been fixed so the tests no longer worrk.