### PR TITLE
Support mojo unseal

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+from zaza.openstack.utilities import (
+    cli as cli_utils,
+    openstack as openstack_utils,
+    openstack_upgrade as upgrade_utils,
+)
+
+
+applications = []
+for group in ['Core Identity', 'Storage', 'Control Plane', 'Compute']:
+    applications.extend(upgrade_utils.SERVICE_GROUPS[group])
+print(applications)

--- a/zaza/openstack/charm_tests/series_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/tests.py
@@ -83,12 +83,14 @@ class SeriesUpgradeTest(unittest.TestCase):
                 pause_non_leader_primary = False
                 pause_non_leader_subordinate = False
             if "vault" in applications[application]["charm"]:
+                origin = None
+                pause_non_leader_primary = False
+                pause_non_leader_subordinate = True
                 post_upgrade_functions = [
                     ('zaza.openstack.charm_tests.vault.setup.'
-                     'basic_unseal_mojo_cacert')]
-            if ("mongodb" in applications[application]["charm"] or
-                    "vault" in applications[application]["charm"]):
-                # Mongodb and vault need to run series upgrade
+                     'mojo_unseal_by_unit')]
+            if "mongodb" in applications[application]["charm"]:
+                # Mongodb needs to run series upgrade
                 # on its secondaries first.
                 generic_utils.series_upgrade_non_leaders_first(
                     application,

--- a/zaza/openstack/charm_tests/series_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/tests.py
@@ -85,7 +85,7 @@ class SeriesUpgradeTest(unittest.TestCase):
             if "vault" in applications[application]["charm"]:
                 post_upgrade_functions = [
                     ('zaza.openstack.charm_tests.vault.setup.'
-                     'basic_setup_and_unseal')]
+                     'basic_unseal_mojo_cacert')]
             if ("mongodb" in applications[application]["charm"] or
                     "vault" in applications[application]["charm"]):
                 # Mongodb and vault need to run series upgrade

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -24,6 +24,7 @@ import zaza.model
 import zaza.openstack.utilities.cert
 import zaza.openstack.utilities.openstack
 import zaza.openstack.utilities.generic
+import zaza.utilities.juju as juju_utils
 
 
 def basic_setup(cacert=None, unseal_and_authorize=False):
@@ -59,7 +60,7 @@ def mojo_unseal_by_unit():
     for client in vault_utils.get_clients(cacert=cacert):
         if client.hvac_client.is_sealed():
             client.hvac_client.unseal(vault_creds['keys'][0])
-            unit_name = zaza.utilities.juju.get_unit_name_from_ip_address(
+            unit_name = juju_utils.get_unit_name_from_ip_address(
                 client.addr,
                 'vault')
             zaza.model.run_on_unit(unit_name, './hooks/update-status')

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -55,7 +55,7 @@ def basic_setup_and_unseal(cacert=None):
 
 def mojo_unseal_by_unit():
     """Unseal any units reported as sealed using mojo cacert."""
-    cacert = zaza.openstack.utilities.generic.get_mojo_cacert()
+    cacert = zaza.openstack.utilities.generic.get_mojo_cacert_path()
     vault_creds = vault_utils.get_credentails()
     for client in vault_utils.get_clients(cacert=cacert):
         if client.hvac_client.is_sealed():

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -15,6 +15,7 @@
 """Run configuration phase."""
 
 import functools
+import os
 import requests
 import tempfile
 
@@ -49,6 +50,23 @@ def basic_setup_and_unseal(cacert=None):
     vault_svc.unseal()
     for unit in zaza.model.get_units('vault'):
         zaza.model.run_on_unit(unit.name, './hooks/update-status')
+
+
+def basic_unseal_mojo_cacert():
+    """Unseal Vault and search for cacert to use.
+
+    This is designed to be used from a mojo spec where certs are stored in the
+    $MOJO_LOCAL directory.
+    """
+    try:
+        cert_dir = os.environ['MOJO_LOCAL']
+    except KeyError:
+        raise Exception("Could not find cacert.pem, MOJO_LOCAL unset")
+    cacert = os.path.join(cert_dir, 'cacert.pem')
+    if os.path.exists(cacert):
+        basic_setup_and_unseal(cacert=cacert)
+    else:
+        raise Exception("Could not find cacert.pem")
 
 
 def auto_initialize(cacert=None, validation_application='keystone'):

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -59,7 +59,7 @@ def basic_unseal_mojo_cacert():
     $MOJO_LOCAL directory.
     """
     try:
-        cert_dir = os.environ['MOJO_LOCAL']
+        cert_dir = os.environ['MOJO_LOCAL_DIR']
     except KeyError:
         raise Exception("Could not find cacert.pem, MOJO_LOCAL unset")
     cacert = os.path.join(cert_dir, 'cacert.pem')

--- a/zaza/openstack/charm_tests/vault/utils.py
+++ b/zaza/openstack/charm_tests/vault/utils.py
@@ -55,6 +55,10 @@ class VaultFacade:
         self.vip_client = get_vip_client(cacert=cacert)
         if self.vip_client:
             self.unseal_client = self.vip_client
+            try:
+                self.unseal_client.hvac_client.is_initialized()
+            except requests.exceptions.ConnectionError:
+                self.unseal_client = self.clients[0]
         else:
             self.unseal_client = self.clients[0]
         self.initialized = is_initialized(self.unseal_client)

--- a/zaza/openstack/charm_tests/vault/utils.py
+++ b/zaza/openstack/charm_tests/vault/utils.py
@@ -55,10 +55,6 @@ class VaultFacade:
         self.vip_client = get_vip_client(cacert=cacert)
         if self.vip_client:
             self.unseal_client = self.vip_client
-            try:
-                self.unseal_client.hvac_client.is_initialized()
-            except requests.exceptions.ConnectionError:
-                self.unseal_client = self.clients[0]
         else:
             self.unseal_client = self.clients[0]
         self.initialized = is_initialized(self.unseal_client)

--- a/zaza/openstack/utilities/exceptions.py
+++ b/zaza/openstack/utilities/exceptions.py
@@ -184,3 +184,9 @@ class PolicydError(Exception):
     """Policyd override failed."""
 
     pass
+
+
+class CACERTNotFound(Exception):
+    """Could not find cacert."""
+
+    pass

--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -850,3 +850,22 @@ def systemctl(unit, service, command="restart"):
         unit.entity_id, cmd)
     assert int(result['Code']) == 0, (
         "{} of {} on {} failed".format(command, service, unit.entity_id))
+
+
+def get_mojo_cacert():
+    """Retrieve cacert from Mojo storage location.
+
+    :returns: Pathh to cacert
+    :rtype: str
+    :raises: zaza_exceptions.CACERTNotFound
+    """
+    try:
+        cert_dir = os.environ['MOJO_LOCAL_DIR']
+    except KeyError:
+        raise zaza_exceptions.CACERTNotFound(
+            "Could not find cacert.pem, MOJO_LOCAL_DIR unset")
+    cacert = os.path.join(cert_dir, 'cacert.pem')
+    if os.path.exists(cacert):
+        return cacert
+    else:
+        raise zaza_exceptions.CACERTNotFound("Could not find cacert.pem")

--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -852,12 +852,13 @@ def systemctl(unit, service, command="restart"):
         "{} of {} on {} failed".format(command, service, unit.entity_id))
 
 
-def get_mojo_cacert():
+def get_mojo_cacert_path():
     """Retrieve cacert from Mojo storage location.
 
-    :returns: Pathh to cacert
+    :returns: Path to cacert
     :rtype: str
     :raises: zaza_exceptions.CACERTNotFound
+    :raises: :class:`zaza_exceptions.CACERTNotfound`
     """
     try:
         cert_dir = os.environ['MOJO_LOCAL_DIR']


### PR DESCRIPTION
Add shim to allow mojo to use zaza to unseal any sealed vault units. To achieve this there is helper function to search for the cacert which mojo is using