### PR TITLE
Upgrade complete action for percona

### DIFF
--- a/zaza/openstack/charm_tests/series_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/tests.py
@@ -126,6 +126,15 @@ class SeriesUpgradeTest(unittest.TestCase):
                     action_params={})
                 model.block_until_all_units_idle()
 
+            if "percona-cluster" in applications[application]["charm"]:
+                logging.info(
+                    "Running complete-cluster-series-upgrade action on leader")
+                model.run_action_on_leader(
+                    'mysql',
+                    'complete-cluster-series-upgrade',
+                    action_params={})
+                model.block_until_all_units_idle()
+
 
 class OpenStackSeriesUpgrade(SeriesUpgradeTest):
     """OpenStack Series Upgrade.


### PR DESCRIPTION
The Percona charm requires that an action is run once all the units
have performed their series upgrade. Longer term
test_200_run_series_upgrade needs refactoring but this is a
tactical fix in the meantime.