### PR TITLE
Percona to MySQL InnoDB Cluster migration

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -33,9 +33,9 @@ class MySQLBaseTest(test_utils.OpenStackBaseTest):
     """Base for mysql charm tests."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls, application_name=None):
         """Run class setup for running mysql tests."""
-        super(MySQLBaseTest, cls).setUpClass()
+        super().setUpClass(application_name=application_name)
         cls.application = "mysql"
         cls.services = ["mysqld"]
         # Config file affected by juju set config change
@@ -555,6 +555,13 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
 
 class MySQL8MigrationTests(MySQLBaseTest):
     """Percona Cluster to MySQL InnoDB Cluster Tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running migration tests."""
+        # Having application_name set avoids breakage in the OpenStackBaseTest class
+        # when running bundle tests without charm_name specified
+        super().setUpClass(application_name="mysql-innodb-cluster")
 
     def test_999_migrate_percona_to_mysql(self):
         """Migrate DBs from percona-cluster to mysql-innodb-cluster.

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -559,8 +559,9 @@ class MySQL8MigrationTests(MySQLBaseTest):
     @classmethod
     def setUpClass(cls):
         """Run class setup for running migration tests."""
-        # Having application_name set avoids breakage in the OpenStackBaseTest class
-        # when running bundle tests without charm_name specified
+        # Having application_name set avoids breakage in the
+        # OpenStackBaseTest class when running bundle tests without
+        # charm_name specified
         super().setUpClass(application_name="mysql-innodb-cluster")
 
     def test_999_migrate_percona_to_mysql(self):

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -558,7 +558,7 @@ class MySQL8MigrationTests(MySQLBaseTest):
 
     def test_999_migrate_percona_to_mysql(self):
         """Migrate DBs from percona-cluster to mysql-innodb-cluster.
-        
+
         Do not rely on self.application_name or other pre-set class values as
         we will be pointing to both percona-cluster and mysql-innodb-cluster.
         """


### PR DESCRIPTION
Validate the migration from percona-cluster to mysql-innodb-cluster by
dumping databases from percona and restoring them in mysql8.