### PR TITLE
Fixes for masakari tests

### DIFF
--- a/zaza/openstack/charm_tests/masakari/tests.py
+++ b/zaza/openstack/charm_tests/masakari/tests.py
@@ -18,6 +18,7 @@
 
 from datetime import datetime
 import logging
+import unittest
 import tenacity
 
 import novaclient
@@ -165,6 +166,7 @@ class MasakariTest(test_utils.OpenStackBaseTest):
 
     def test_instance_restart_on_fail(self):
         """Test singlee guest crash and recovery."""
+        raise unittest.SkipTest("Bug #1866638")
         vm_name = 'zaza-test-instance-failover'
         vm = self.ensure_guest(vm_name)
         _, unit_name = self.get_guests_compute_info(vm_name)

--- a/zaza/openstack/configure/masakari.py
+++ b/zaza/openstack/configure/masakari.py
@@ -39,7 +39,7 @@ def roundrobin_assign_hosts_to_segments(nova_client, masakari_client):
     segment_ids = segment_ids * len(hypervisors)
     for hypervisor in hypervisors:
         target_segment = segment_ids.pop()
-        hostname = hypervisor.hypervisor_hostname.split('.')[0]
+        hostname = hypervisor.hypervisor_hostname
         logging.info('Adding {} to segment {}'.format(hostname,
                                                       target_segment))
         masakari_client.create_host(

--- a/zaza/openstack/utilities/juju.py
+++ b/zaza/openstack/utilities/juju.py
@@ -114,8 +114,9 @@ def get_unit_name_from_host_name(host_name, application, model_name=None):
     :param model_name: Name of model to query.
     :type model_name: str
     """
-    # Assume that a juju managed hostname always ends in the machine number.
-    machine_number = host_name.split('-')[-1]
+    # Assume that a juju managed hostname always ends in the machine number and
+    # remove the domain name if it present.
+    machine_number = host_name.split('-')[-1].split('.')[0]
     unit_names = [
         u.entity_id
         for u in model.get_units(application_name=application,


### PR DESCRIPTION
* Deal with hypervisors now using fqdn
* Skip instant restart tests until bug is resolved