### PR TITLE
keystone: expect security check no admin-token to pass

### DIFF
--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -328,6 +328,21 @@ class AuthenticationAuthorizationTest(BaseKeystoneTest):
                         {'OS_AUTH_URL': 'http://{}:5000/v3'.format(ip)})
                     _validate_token_data(openrc)
 
+    def test_backward_compatible_uuid_for_default_domain(self):
+        """Check domain named ``default`` literally has ``default`` as ID.
+
+        Some third party software chooses to hard code this value for some
+        inexplicable reason.
+        """
+        with self.v3_keystone_preferred():
+            ks_session = openstack_utils.get_keystone_session(
+                openstack_utils.get_overcloud_auth())
+            ks_client = openstack_utils.get_keystone_session_client(
+                ks_session)
+            domain = ks_client.domains.get('default')
+            logging.info(pprint.pformat(domain))
+            assert domain.id == 'default'
+
 
 class SecurityTests(BaseKeystoneTest):
     """Keystone security tests tests."""
@@ -343,13 +358,13 @@ class SecurityTests(BaseKeystoneTest):
         # this initial work to get validation in. There will be bugs targeted
         # to each one and resolved independently where possible.
         expected_failures = [
-            'disable-admin-token',
         ]
         expected_passes = [
             'check-max-request-body-size',
-            'uses-sha256-for-hashing-tokens',
-            'uses-fernet-token-after-default',
+            'disable-admin-token',
             'insecure-debug-is-false',
+            'uses-fernet-token-after-default',
+            'uses-sha256-for-hashing-tokens',
             'validate-file-ownership',
             'validate-file-permissions',
         ]
@@ -363,7 +378,7 @@ class SecurityTests(BaseKeystoneTest):
                 action_params={}),
             expected_passes,
             expected_failures,
-            expected_to_pass=False)
+            expected_to_pass=True)
 
 
 class LdapTests(BaseKeystoneTest):

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -258,7 +258,7 @@ class BasePolicydSpecialization(PolicydTest,
 
         class KeystonePolicydTest(BasePolicydSpecialization):
 
-            _rule = {'rule.yaml': "{'identity:list_services': '!'}"}
+            _rule = {'rule.yaml': "{'identity:list_credentials': '!'}"}
 
             def get_client_and_attempt_operation(self, keystone_session):
                 ... etc.
@@ -485,7 +485,7 @@ class BasePolicydSpecialization(PolicydTest,
 class KeystoneTests(BasePolicydSpecialization):
     """Test the policyd override using the keystone client."""
 
-    _rule = {'rule.yaml': "{'identity:list_services': '!'}"}
+    _rule = {'rule.yaml': "{'identity:list_credentials': '!'}"}
 
     @classmethod
     def setUpClass(cls, application_name=None):
@@ -506,7 +506,7 @@ class KeystoneTests(BasePolicydSpecialization):
         keystone_client = openstack_utils.get_keystone_session_client(
             self.get_keystone_session_demo_admin_user(ip))
         try:
-            keystone_client.services.list()
+            keystone_client.credentials.list()
         except keystoneauth1.exceptions.http.Forbidden:
             raise PolicydOperationFailedException()
 


### PR DESCRIPTION
Also add test to validate that the domain named ``default``
literally has an ID of ``default``.