### PR TITLE
radosgw: Adjust exceptions selected for retry

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -597,8 +597,7 @@ class CephRGWTest(test_utils.OpenStackBaseTest):
     # catalog.  Retry the test in this circumstance.
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=10, max=300),
                     reraise=True, stop=tenacity.stop_after_attempt(10),
-                    retry=tenacity.retry_if_exception_type(
-                        ConnectionRefusedError))
+                    retry=tenacity.retry_if_exception_type(IOError))
     def test_object_storage(self):
         """Verify object storage API.
 


### PR DESCRIPTION
A set of the exceptions we want to catch all descend from
``IOError``.  Let's see if this covers them all.