### PR TITLE
mysql: add test for mark-seeded action

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -231,6 +231,22 @@ class PerconaClusterCharmTests(MySQLCommonTests, PerconaClusterBaseTest):
 
             assert code == "0", output
 
+    def test_140_mark_seeded_action(self):
+        """Test mark-seeded action in leader unit.
+
+        Remove seeded file and recreate it using the action.
+        """
+        cmd = "sudo rm -f /var/lib/percona-xtradb-cluster/seeded"
+        result = zaza.model.run_on_leader(self.application, cmd)
+        msg = "Stdout: %s, Stderr: %s" % (result.get("Stdout"),
+                                          result.get("Stderr"))
+        assert result.get("Code") == "0", msg
+
+        action = zaza.model.run_action_on_leader(self.application,
+                                                 "mark-seeded")
+        assert "Success" in action.data["results"]["outcome"], \
+            "mark-seeded action failed: {}".format(action.data)
+
 
 class PerconaClusterColdStartTest(PerconaClusterBaseTest):
     """Percona Cluster cold start tests."""


### PR DESCRIPTION
This test removes the seeded file by ssh, then runs the mark-seeded
action and checks the output of the action.

Related-bug: #1867456