### PR TITLE
Add tests for Ceph integration with K8s

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -33,6 +33,7 @@ import zaza.openstack.utilities.ceph as zaza_ceph
 import zaza.openstack.utilities.exceptions as zaza_exceptions
 import zaza.openstack.utilities.generic as zaza_utils
 import zaza.openstack.utilities.juju as zaza_juju
+import zaza.openstack.utilities.kubernetes as zaza_k8s
 import zaza.openstack.utilities.openstack as zaza_openstack
 
 
@@ -760,3 +761,24 @@ class CephProxyTest(unittest.TestCase):
             msg = ('cinder-ceph pool restriction was not configured correctly.'
                    ' Found: {}'.format(output))
             raise zaza_exceptions.CephPoolNotConfigured(msg)
+
+
+class CephK8sTest(unittest.TestCase):
+    """Test Ceph RBD integration with CK."""
+
+    def test_k8s_ceph_rbd(self):
+        logging.info('Wait for idle/ready status...')
+        zaza_model.wait_for_application_states()
+
+        zaza_k8s.validate_storage_class("ceph-ext4")
+        zaza_k8s.validate_storage_class("ceph-xfs")
+
+
+class CephFSK8sTest(unittest.TestCase):
+    """Test CephFS integration with CK."""
+
+    def test_k8s_ceph_fs(self):
+        logging.info('Wait for idle/ready status...')
+        zaza_model.wait_for_application_states()
+
+        zaza_k8s.validate_storage_class("ceph-fs")

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -767,6 +767,12 @@ class CephK8sTest(unittest.TestCase):
     """Test Ceph RBD integration with CK."""
 
     def test_k8s_ceph_rbd(self):
+        """
+        Validate ceph-ext4 and ceph-xfs volumes backed by Ceph RBD.
+
+        Confirm that volumes for each filesystem type can be provisioned,
+        written to, then read from.
+        """
         logging.info('Wait for idle/ready status...')
         zaza_model.wait_for_application_states()
 
@@ -778,6 +784,11 @@ class CephFSK8sTest(unittest.TestCase):
     """Test CephFS integration with CK."""
 
     def test_k8s_ceph_fs(self):
+        """
+        Validate ceph-fs volumes backed by CephFS.
+
+        Confirm that volumes can be provisioned, written to, then read from.
+        """
         logging.info('Wait for idle/ready status...')
         zaza_model.wait_for_application_states()
 

--- a/zaza/openstack/utilities/kubernetes.py
+++ b/zaza/openstack/utilities/kubernetes.py
@@ -61,6 +61,12 @@ spec:
 
 
 async def async_kubectl(cmd):
+    """
+    Invoke a kubectl command, assert that it was successful, and return output.
+
+    If the return code is not 0, it will raise an AssertionError with a message
+    containing the command, it's exit code, and the stderr output.
+    """
     cmd = "/snap/bin/kubectl {}".format(cmd)
     result = await zaza.model.async_run_on_leader("kubernetes-master", cmd)
     assert result["Code"] == 0, "'kubectl {}' failed ({}): {}".format(
@@ -73,6 +79,12 @@ kubectl = zaza.sync_wrapper(async_kubectl)
 
 
 async def async_wait_for_pod_complete(pod_name):
+    """
+    Watch for a pod to go to Completed status.
+
+    Will wait up to 60 seconds (6 attempts with 10 second intervals) before
+    raising a ModelTimeout exception.
+    """
     for attempt in range(6):
         pod_status = await async_kubectl("get pod {}".format(pod_name))
         if "Completed" in pod_status:
@@ -89,7 +101,6 @@ wait_for_pod_complete = zaza.sync_wrapper(async_wait_for_pod_complete)
 
 def validate_storage_class(sc_name):
     """Validate the given SC can be written to and read from."""
-
     write_pod_name = "{}-write-test".format(sc_name)
     read_pod_name = "{}-read-pod-test".format(sc_name)
 

--- a/zaza/openstack/utilities/kubernetes.py
+++ b/zaza/openstack/utilities/kubernetes.py
@@ -1,0 +1,111 @@
+"""Module containing Kubernetes related utilities."""
+import asyncio
+
+import zaza
+
+
+WRITE_POD = """
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {0}-pvc
+  annotations:
+   volume.beta.kubernetes.io/storage-class: {0}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: {0}-write-test
+spec:
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: {0}-pvc
+      readOnly: false
+  containers:
+    - name: {0}-write-test
+      image: ubuntu
+      command: ["/bin/bash", "-c", "echo 'JUJU TEST' > /data/juju"]
+      volumeMounts:
+      - name: shared-data
+        mountPath: /data
+  restartPolicy: Never
+"""
+
+READ_POD = """
+kind: Pod
+apiVersion: v1
+metadata:
+  name: {0}-read-test
+spec:
+  volumes:
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: {0}-pvc
+      readOnly: false
+  containers:
+    - name: {0}-read-test
+      image: ubuntu
+      command: ["/bin/bash", "-c", "cat /data/juju"]
+      volumeMounts:
+      - name: shared-data
+        mountPath: /data
+  restartPolicy: Never
+"""
+
+
+async def async_kubectl(cmd):
+    cmd = "/snap/bin/kubectl {}".format(cmd)
+    result = await zaza.model.async_run_on_leader("kubernetes-master", cmd)
+    assert result["Code"] == 0, "'kubectl {}' failed ({}): {}".format(
+        cmd, result["Code"], result["Stderr"],
+    )
+    return result["Stdout"]
+
+
+kubectl = zaza.sync_wrapper(async_kubectl)
+
+
+async def async_wait_for_pod_complete(pod_name):
+    for attempt in range(6):
+        pod_status = await async_kubectl("get pod {}".format(pod_name))
+        if "Completed" in pod_status:
+            break
+        else:
+            await asyncio.sleep(10)
+    else:
+        raise zaza.model.ModelTimeout("Timed out waiting for Kubernetes "
+                                      "pod {} to complete".format(pod_name))
+
+
+wait_for_pod_complete = zaza.sync_wrapper(async_wait_for_pod_complete)
+
+
+def validate_storage_class(sc_name):
+    """Validate the given SC can be written to and read from."""
+
+    write_pod_name = "{}-write-test".format(sc_name)
+    read_pod_name = "{}-read-pod-test".format(sc_name)
+
+    storage_classes = kubectl("get sc")
+    assert sc_name in storage_classes, ("Storage class {} not found in "
+                                        "{}".format(sc_name, storage_classes))
+
+    kubectl("create -f - << EOF{}EOF".format(WRITE_POD.format(sc_name)))
+    wait_for_pod_complete(write_pod_name)
+
+    kubectl("create -f - << EOF{}EOF".format(READ_POD.format(sc_name)))
+    wait_for_pod_complete(read_pod_name)
+
+    read_output = kubectl("logs {}".format(read_pod_name))
+    assert "JUJU TEST" in read_output, ("Expected output 'JUJU TEST' not "
+                                        "found in: {}".format(read_output))
+
+    kubectl("delete pod {} {}".format(read_pod_name, write_pod_name))
+    kubectl("delete pvc {}-pvc".format(sc_name))


### PR DESCRIPTION
Adding tests for Ceph RBD and CephFS support in K8s so that changes to the Ceph charms can be validated against the Charmed Kubernetes usage.

Currently a draft because I've had to set this aside for the moment and haven't had a chance to do a full run yet (see the issues I ran into in the charm PRs \[to-be-linked\]), but "allow edits from maintainers" is on in case someone wants to take this over and get it landed before I have a chance to get back to it.