### PR TITLE
Add codecov configuration to exclude the charm tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "zaza/openstack/charm_tests/**/*tests.py"


### PR DESCRIPTION
This does not, however, exclude the configure code in
charm_tests as that can, and should, be unit tested :)