### PR TITLE
Temporarily disable test_800_ovs_bridges_are_managed_by_us

### DIFF
--- a/zaza/openstack/charm_tests/neutron/tests.py
+++ b/zaza/openstack/charm_tests/neutron/tests.py
@@ -115,12 +115,16 @@ class NeutronGatewayTest(NeutronPluginApiSharedTests):
 
     _APP_NAME = 'neutron-gateway'
 
+    @unittest.expectedFailure
     def test_800_ovs_bridges_are_managed_by_us(self):
         """Checking OVS bridges' external-id.
 
         OVS bridges created by us should be marked as managed by us in their
         external-id. See
         http://docs.openvswitch.org/en/latest/topics/integration/
+
+        NOTE(lourot): this test is expected to fail as long as this feature
+        hasn't landed yet: https://review.opendev.org/717074
         """
         for unit in zaza.model.get_units(self._APP_NAME,
                                          model_name=self.model_name):


### PR DESCRIPTION
We merged #217 a bit too early, i.e. we have landed the test before the feature.

Validated locally:

```
2020-04-17 05:41:13 [INFO] test_800_ovs_bridges_are_managed_by_us (zaza.openstack.charm_tests.neutron.tests.NeutronGatewayTest)
2020-04-17 05:41:13 [INFO] Checking OVS bridges' external-id.
2020-04-17 05:41:13 [INFO]  ...
2020-04-17 05:41:13 [INFO] Checking that the bridge neutron-gateway/0:br-int is marked as managed by us
2020-04-17 05:41:14 [INFO] expected failure
```