### PR TITLE
Migrate 499 cinder-ceph test to zaza

### DIFF
--- a/zaza/openstack/charm_tests/ceph/mon/__init__.py
+++ b/zaza/openstack/charm_tests/ceph/mon/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collection of code for setting up and testing ceph-mon for cinder-ceph."""

--- a/zaza/openstack/charm_tests/ceph/mon/tests.py
+++ b/zaza/openstack/charm_tests/ceph/mon/tests.py
@@ -86,6 +86,7 @@ class CinderCephMonTest(test_utils.OpenStackBaseTest):
         logging.info("Removing ceph-mon:client <-> cinder-ceph:ceph relation")
         zaza.model.remove_relation(
             "ceph-mon", "ceph-mon:client", "cinder-ceph:ceph")
+        zaza.model.wait_for_agent_status()
         logging.info("Wait till model is idle ...")
         zaza.model.block_until_all_units_idle()
 
@@ -104,6 +105,7 @@ class CinderCephMonTest(test_utils.OpenStackBaseTest):
         logging.info("Restoring ceph-mon:client <-> cinder-ceph:ceph relation")
         zaza.model.add_relation(
             "ceph-mon", "ceph-mon:client", "cinder-ceph:ceph")
+        zaza.model.wait_for_agent_status()
         logging.info("Wait till model is idle ...")
         zaza.model.block_until_all_units_idle()
         logging.info("... Done.")

--- a/zaza/openstack/charm_tests/ceph/mon/tests.py
+++ b/zaza/openstack/charm_tests/ceph/mon/tests.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ceph-mon Testing for cinder-ceph."""
+
+import logging
+import unittest
+
+import zaza.model
+
+from zaza.openstack.utilities import (
+    generic as generic_utils,
+    openstack as openstack_utils,
+)
+
+
+class CinderCephMonTest(unittest.TestCase):
+    """Verify that the ceph mon units are healthy."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running ceph security tests."""
+        super().setUpClass()
+
+    # ported from the cinder-ceph Amulet test
+    def test_499_ceph_cmds_exit_zero(self):
+        """Verify expected state with security-checklist."""
+        logging.info("Checking exit values are 0 on ceph commands.")
+
+        units = zaza.model.get_units("ceph-mon", model_name=self.model_name)
+        current_release = openstack_utils.get_os_release()
+        bionic_train = openstack_utils.get_os_release('bionic_train')
+        if current_release < bionic_train:
+            units.extend(zaza.model.get_utils("cinder-ceph",
+                                              model_name=self.model_name))
+
+        commands = [
+            'sudo ceph health',
+            'sudo ceph mds stat',
+            'sudo ceph pg stat',
+            'sudo ceph osd stat',
+            'sudo ceph mon stat',
+        ]
+
+        for unit in units:
+            run_commands(unit.name, commands)
+
+
+def run_commands(self, unit_name, commands):
+    """Run commands on unit.
+
+    Apply context to commands until all variables have been replaced, then
+    run the command on the given unit.
+    """
+    for cmd in commands:
+        generic_utils.assertRemoteRunOK(zaza.model.run_on_unit(
+            unit_name,
+            cmd))

--- a/zaza/openstack/charm_tests/ceph/mon/tests.py
+++ b/zaza/openstack/charm_tests/ceph/mon/tests.py
@@ -23,14 +23,15 @@ from zaza.openstack.utilities import (
     generic as generic_utils,
     openstack as openstack_utils,
 )
+import zaza.openstack.charm_tests.test_utils as test_utils
 
 
-class CinderCephMonTest(unittest.TestCase):
+class CinderCephMonTest(test_utils.OpenStackBaseTest):
     """Verify that the ceph mon units are healthy."""
 
     @classmethod
     def setUpClass(cls):
-        """Run class setup for running ceph security tests."""
+        """Run class setup for running ceph mon tests with cinder."""
         super().setUpClass()
 
     # ported from the cinder-ceph Amulet test
@@ -57,7 +58,7 @@ class CinderCephMonTest(unittest.TestCase):
             run_commands(unit.name, commands)
 
 
-def run_commands(self, unit_name, commands):
+def run_commands(unit_name, commands):
     """Run commands on unit.
 
     Apply context to commands until all variables have been replaced, then

--- a/zaza/openstack/charm_tests/ceph/mon/tests.py
+++ b/zaza/openstack/charm_tests/ceph/mon/tests.py
@@ -85,7 +85,7 @@ class CinderCephMonTest(test_utils.OpenStackBaseTest):
         # remove the relation so that /etc/ceph/ceph.conf is removed
         logging.info("Removing ceph-mon:client <-> cinder-ceph:ceph relation")
         zaza.model.remove_relation(
-            "ceph-mon", "ceph-mon:client" "cinder-ceph:ceph")
+            "ceph-mon", "ceph-mon:client", "cinder-ceph:ceph")
         logging.info("Wait till model is idle ...")
         zaza.model.block_until_all_units_idle()
 
@@ -103,7 +103,7 @@ class CinderCephMonTest(test_utils.OpenStackBaseTest):
         # Restore cinder-ceph and ceph-mon relation to keep tests idempotent
         logging.info("Restoring ceph-mon:client <-> cinder-ceph:ceph relation")
         zaza.model.add_relation(
-            "ceph-mon", "ceph-mon:client" "cinder-ceph:ceph")
+            "ceph-mon", "ceph-mon:client", "cinder-ceph:ceph")
         logging.info("Wait till model is idle ...")
         zaza.model.block_until_all_units_idle()
         logging.info("... Done.")

--- a/zaza/openstack/charm_tests/cinder/tests.py
+++ b/zaza/openstack/charm_tests/cinder/tests.py
@@ -24,7 +24,6 @@ import zaza.openstack.utilities.openstack as openstack_utils
 import zaza.openstack.charm_tests.glance.setup as glance_setup
 
 from tenacity import (
-    RetryError,
     Retrying,
     stop_after_attempt,
     wait_exponential,
@@ -57,7 +56,8 @@ class CinderTests(test_utils.OpenStackBaseTest):
                 wait=wait_exponential(multiplier=1, min=2, max=60)):
             with attempt:
                 volumes = list(cls.cinder_client.volumes.list())
-                snapped_volumes = [v for v in volumes if v.name.endswith("-from-snap")]
+                snapped_volumes = [v for v in volumes
+                                   if v.name.endswith("-from-snap")]
                 if snapped_volumes:
                     logging.info("Removing volumes from snapshot")
                     cls._remove_volumes(snapped_volumes)

--- a/zaza/openstack/charm_tests/cinder/tests.py
+++ b/zaza/openstack/charm_tests/cinder/tests.py
@@ -126,12 +126,18 @@ class CinderTests(test_utils.OpenStackBaseTest):
 
     def test_105_volume_create_from_img(self):
         """Test creating a volume from an image."""
+        logging.debug("finding image {} ..."
+                      .format(glance_setup.LTS_IMAGE_NAME)
         image = self.nova_client.glance.find_image(
             glance_setup.LTS_IMAGE_NAME)
+        logging.debug("using cinder_client to create volume from image {}"
+                      .format(image.id))
         vol_img = self.cinder_client.volumes.create(
             name='{}-105-vol-from-img'.format(self.RESOURCE_PREFIX),
             size=3,
             imageRef=image.id)
+        logging.debug("now waiting for volume {} to reach available"
+                      .format(vol_img.id))
         openstack_utils.resource_reaches_status(
             self.cinder_client.volumes,
             vol_img.id,

--- a/zaza/openstack/charm_tests/cinder/tests.py
+++ b/zaza/openstack/charm_tests/cinder/tests.py
@@ -127,7 +127,7 @@ class CinderTests(test_utils.OpenStackBaseTest):
     def test_105_volume_create_from_img(self):
         """Test creating a volume from an image."""
         logging.debug("finding image {} ..."
-                      .format(glance_setup.LTS_IMAGE_NAME)
+                      .format(glance_setup.LTS_IMAGE_NAME))
         image = self.nova_client.glance.find_image(
             glance_setup.LTS_IMAGE_NAME)
         logging.debug("using cinder_client to create volume from image {}"

--- a/zaza/openstack/utilities/exceptions.py
+++ b/zaza/openstack/utilities/exceptions.py
@@ -168,6 +168,12 @@ class CephPoolNotConfigured(Exception):
     pass
 
 
+class CephGenericError(Exception):
+    """A generic/other Ceph error occurred."""
+
+    pass
+
+
 class NovaGuestMigrationFailed(Exception):
     """Nova guest migration failed."""
 


### PR DESCRIPTION
This takes the 499 test from basic_deployment.py (Amulet) test and
ports it over to zaza.