### PR TITLE
Disable the pristine disk check on focal

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -371,6 +371,13 @@ class CephTest(test_utils.OpenStackBaseTest):
         As the ephemeral device will have data on it we can use it to validate
         that these checks work as intended.
         """
+        current_release = zaza_openstack.get_os_release()
+        focal_ussuri = zaza_openstack.get_os_release('focal_ussuri')
+        if current_release >= focal_ussuri:
+            # NOTE(ajkavanagh) - focal (on ServerStack) is broken for /dev/vdb
+            # and so this test can't pass
+            logging.warn("Skipping pristine disk test for focal and higher")
+            return
         logging.info('Checking behaviour when non-pristine disks appear...')
         logging.info('Configuring ephemeral-unmount...')
         alternate_conf = {

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -375,7 +375,13 @@ class CephTest(test_utils.OpenStackBaseTest):
         focal_ussuri = zaza_openstack.get_os_release('focal_ussuri')
         if current_release >= focal_ussuri:
             # NOTE(ajkavanagh) - focal (on ServerStack) is broken for /dev/vdb
-            # and so this test can't pass
+            # and so this test can't pass: LP#1842751 discusses the issue, but
+            # basically the snapd daemon along with lxcfs results in /dev/vdb
+            # being mounted in the lxcfs process namespace.  If the charm
+            # 'tries' to umount it, it can (as root), but the mount is still
+            # 'held' by lxcfs and thus nothing else can be done with it.  This
+            # is only a problem in serverstack with images with a default
+            # /dev/vdb ephemeral
             logging.warn("Skipping pristine disk test for focal and higher")
             return
         logging.info('Checking behaviour when non-pristine disks appear...')


### PR DESCRIPTION
The test won't pass on serverstack due to the snapd taking a copy of the
/mnt/vdb info at boot time and thus not being able to umount it is root
without also running through all of the procs and checking if they also
have it mounted.  Thus, this just disables the test on focal and newer.