### PR TITLE
Pass arguments BaseCharmTest.setUpClass

### DIFF
--- a/unit_tests/charm_tests/test_utils.py
+++ b/unit_tests/charm_tests/test_utils.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import zaza.openstack.charm_tests.test_utils as test_utils
+
+from unittest.mock import patch
+
+
+class TestOpenStackBaseTest(unittest.TestCase):
+
+    @patch.object(test_utils.openstack_utils, 'get_cacert')
+    @patch.object(test_utils.openstack_utils, 'get_overcloud_keystone_session')
+    @patch.object(test_utils.BaseCharmTest, 'setUpClass')
+    def test_setUpClass(self, _setUpClass, _get_ovcks, _get_cacert):
+
+        class MyTestClass(test_utils.OpenStackBaseTest):
+            model_name = 'deadbeef'
+
+        MyTestClass.setUpClass('foo', 'bar')
+        _setUpClass.assert_called_with('foo', 'bar')

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -427,7 +427,7 @@ class OpenStackBaseTest(BaseCharmTest):
     @classmethod
     def setUpClass(cls, application_name=None, model_alias=None):
         """Run setup for test class to create common resources."""
-        super(OpenStackBaseTest, cls).setUpClass()
+        super(OpenStackBaseTest, cls).setUpClass(application_name, model_alias)
         cls.keystone_session = openstack_utils.get_overcloud_keystone_session(
             model_name=cls.model_name)
         cls.cacert = openstack_utils.get_cacert()


### PR DESCRIPTION
Not doing so triggers an incorrect behavior leading to functional test
failures as the application name is not set correctly.

https://github.com/openstack-charmers/zaza-openstack-tests/issues/256
https://review.opendev.org/#/c/712980/1