### PR TITLE
Make masakari wait longer for hosts to online

### DIFF
--- a/zaza/openstack/configure/masakari.py
+++ b/zaza/openstack/configure/masakari.py
@@ -85,7 +85,7 @@ def create_segments(segment_number=1, host_assignment_method=None):
 
 @tenacity.retry(
     wait=tenacity.wait_exponential(multiplier=2, max=60),
-    reraise=True, stop=tenacity.stop_after_attempt(5),
+    reraise=True, stop=tenacity.stop_after_attempt(10),
     retry=tenacity.retry_if_exception_type(ostack_except.ConflictException))
 def enable_host(masakari_client, host, segment):
     """Enable hypervisor within masakari.


### PR DESCRIPTION
A recent functional test of masakari monitors failed due to a
tenacity retry missing the host coming online by 10s, so wait
longer. FWIW that this affects the post-test cleanup rather than
the test itself.

*1 https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_full/openstack/charm-masakari-monitors/726808/1/5655/consoleText.test_charm_func_full_8812.txt
`