### PR TITLE
Handle reboot_from_complete_outage for mysql-innodb-cluster

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -558,17 +558,24 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
             self.resolve_update_status_errors()
             zaza.model.block_until_all_units_idle()
 
-        logging.debug("Wait for application states ...")
+        logging.debug("Clear error hooks after reboot ...")
         for unit in zaza.model.get_units(self.application):
             try:
                 zaza.model.run_on_unit(unit.entity_id, "hooks/update-status")
             except zaza.model.UnitError:
                 self.resolve_update_status_errors()
                 zaza.model.run_on_unit(unit.entity_id, "hooks/update-status")
-        states = {self.application: {
-            "workload-status": "blocked",
-            "workload-status-message":
-                "MySQL InnoDB Cluster not healthy: None"}}
+        logging.debug("Wait for application states blocked ...")
+        states = {
+            self.application: {
+                "workload-status": "blocked",
+                "workload-status-message":
+                    "MySQL InnoDB Cluster not healthy: None"},
+            "mysql-router": {
+                "workload-status": "blocked",
+                "workload-status-message":
+                    "Failed to connect to MySQL"}}
+
         zaza.model.wait_for_application_states(states=states)
 
         logging.info("Execute reboot-cluster-from-complete-outage "
@@ -580,8 +587,11 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
                 unit.entity_id,
                 "reboot-cluster-from-complete-outage",
                 action_params={})
-            if action.data["results"].get("outcome"):
+            if "Success" in action.data["results"].get("outcome"):
                 break
+            else:
+                loggging.info(action.data["results"].get("output"))
+
         assert "Success" in action.data["results"]["outcome"], (
             "Reboot cluster from complete outage action failed: {}"
             .format(action.data))
@@ -734,7 +744,7 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
         leader_unit = zaza.model.get_unit_from_name(leader)
         zaza.model.destroy_unit(self.application_name, leader)
 
-        logging.info("Wait units are waiting ...")
+        logging.info("Wait until unit is in waiting state ...")
         zaza.model.block_until_unit_wl_status(nons[0], "waiting")
 
         logging.info("Wait till model is idle ...")

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -590,7 +590,7 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
             if "Success" in action.data["results"].get("outcome"):
                 break
             else:
-                loggging.info(action.data["results"].get("output"))
+                logging.info(action.data["results"].get("output"))
 
         assert "Success" in action.data["results"]["outcome"], (
             "Reboot cluster from complete outage action failed: {}"


### PR DESCRIPTION
Test updates to re-enable reboot_from_complete_outage testing on
mysql-innodb-cluster.