### PR TITLE
Unpin juju (libjuju) from < 2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiounittest
 async_generator
 boto3
-juju<2.8.0
+juju
 juju_wait
 PyYAML<=4.2,>=3.0
 flake8>=2.2.4

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_require = [
     'cryptography',
     'hvac<0.7.0',
     'jinja2',
-    'juju<2.8.0',
+    'juju',
     'juju-wait',
     'lxml',
     'PyYAML',


### PR DESCRIPTION
python-libjuju was broken at 2.8 and thus zaza and zaza-openstack-tests
needed to be pinned to < 2.8.  This patch releases that so that the
latest versions of libjuju are used in testing.  This may get pinned
again before the next release window.