### PR TITLE
Retrieve ssl-ca from vault when using vault api

### DIFF
--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -29,9 +29,9 @@ import zaza.utilities.juju as juju_utils
 
 
 def get_cacert_file():
-    """Retrieve CA cert used for vault EP and write to file.
+    """Retrieve CA cert used for vault endpoints and write to file.
 
-    :returns: Path to file with CA cert used for Vault EPs
+    :returns: Path to file with CA cert.
     :rtype: str
     """
     cacert_file = None


### PR DESCRIPTION
If the ssl-{key,chain,ca} charm config option have been set than
retrieve the ssl-ca from the vault charm and use it when making
called to the vault api.