### PR TITLE
Wait until a share status reaches 'available'

### DIFF
--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -74,6 +74,15 @@ packages:
         fip_1 = neutron_tests.floating_ips_from_instance(instance_1)[0]
         fip_2 = neutron_tests.floating_ips_from_instance(instance_2)[0]
 
+        # Wait for the created share to become available before it gets used.
+        openstack_utils.resource_reaches_status(
+            self.manila_client.shares,
+            share.id,
+            wait_iteration_max_time=1200,
+            stop_after_attempt=20,
+            expected_status="available",
+            msg="Waiting for a share to become available")
+
         share.allow(access_type='ip', access=fip_1, access_level='rw')
         share.allow(access_type='ip', access=fip_2, access_level='rw')
 

--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -78,8 +78,8 @@ packages:
         openstack_utils.resource_reaches_status(
             self.manila_client.shares,
             share.id,
-            wait_iteration_max_time=1200,
-            stop_after_attempt=20,
+            wait_iteration_max_time=120,
+            stop_after_attempt=2,
             expected_status="available",
             msg="Waiting for a share to become available")
 


### PR DESCRIPTION
It appears to be that the test_manila_share test case does not wait
until a share becomes available which results in failures like this:

manilaclient.common.apiclient.exceptions.BadRequest: New access rules
cannot be applied while the share or any of its replicas or migration
copies lacks a valid host or is in an invalid state. (HTTP 400)
(Request-ID: req-8d609e13-9a80-428b-953b-17ab8d0e0cae)

Fixes: #309
