### PR TITLE
Drop check for tempest workspace directory

### DIFF
--- a/zaza/openstack/charm_tests/tempest/setup.py
+++ b/zaza/openstack/charm_tests/tempest/setup.py
@@ -15,7 +15,6 @@
 """Code for configuring and initializing tempest."""
 
 import urllib.parse
-import os
 import subprocess
 
 import zaza.utilities.deployment_env as deployment_env
@@ -253,12 +252,11 @@ def setup_tempest(tempest_template, accounts_template):
     :returns: None
     :rtype: None
     """
-    if os.path.isdir('tempest-workspace'):
-        try:
-            subprocess.check_call(['tempest', 'workspace', 'remove', '--rmdir',
-                                   '--name', 'tempest-workspace'])
-        except subprocess.CalledProcessError:
-            pass
+    try:
+        subprocess.check_call(['tempest', 'workspace', 'remove', '--rmdir',
+                               '--name', 'tempest-workspace'])
+    except subprocess.CalledProcessError:
+        pass
     try:
         subprocess.check_call(['tempest', 'init', 'tempest-workspace'])
     except subprocess.CalledProcessError:


### PR DESCRIPTION
This check is not necessary. The workspace is recreated on each
run, so just attempt to remove the workspace each time.