### PR TITLE
Add setup for glance-simplestreams-sync

### DIFF
--- a/zaza/openstack/charm_tests/glance_simplestreams_sync/setup.py
+++ b/zaza/openstack/charm_tests/glance_simplestreams_sync/setup.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Code for configuring glance-simplestreams-sync."""
+
+import logging
+
+import zaza.model as zaza_model
+import zaza.openstack.utilities.generic as generic_utils
+
+
+def sync_images():
+    """Run image sync using an action.
+
+    Execute an initial image sync using an action to ensure that the
+    cloud is populated with images at the right point in time during
+    deployment.
+    """
+    logging.info("Synchronising images using glance-simplestreams-sync")
+    generic_utils.assertActionRanOK(
+        zaza_model.run_action_on_leader(
+            "glance-simplestreams-sync",
+            "sync-images",
+            raise_on_failure=True,
+            action_params={},
+        )
+    )

--- a/zaza/openstack/charm_tests/glance_simplestreams_sync/tests.py
+++ b/zaza/openstack/charm_tests/glance_simplestreams_sync/tests.py
@@ -24,7 +24,7 @@ import zaza.openstack.utilities.openstack as openstack_utils
 
 
 @tenacity.retry(
-    retry=tenacity.retry_if_result(lambda images: len(images) < 3),
+    retry=tenacity.retry_if_result(lambda images: len(images) < 4),
     wait=tenacity.wait_fixed(6),  # interval between retries
     stop=tenacity.stop_after_attempt(100))  # retry times
 def retry_image_sync(glance_client):
@@ -61,7 +61,7 @@ class GlanceSimpleStreamsSyncTest(test_utils.OpenStackBaseTest):
             cls.keystone_session)
 
     def test_010_wait_for_image_sync(self):
-        """Wait for images to be synced. Expect at least three."""
+        """Wait for images to be synced. Expect at least four."""
         self.assertTrue(retry_image_sync(self.glance_client))
 
     def test_050_gss_permissions_regression_check_lp1611987(self):
@@ -94,6 +94,7 @@ class GlanceSimpleStreamsSyncTest(test_utils.OpenStackBaseTest):
             'com.ubuntu.cloud:server:14.04:amd64',
             'com.ubuntu.cloud:server:16.04:amd64',
             'com.ubuntu.cloud:server:18.04:amd64',
+            'com.ubuntu.cloud:server:20.04:amd64',
         ]
         uri = "streams/v1/auto.sync.json"
         key = "url"


### PR DESCRIPTION
Use action to complete initial image sync for the gss charm.

This avoids races where the images end up in the wrong locations
and allows the tests to actually know when images should be
discoverable.

Update tests to wait for at least four images (20.04 is synced
by default).