### PR TITLE
Store local overcloud CACERT copy in relative path

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -163,7 +163,7 @@ WORKLOAD_STATUS_EXCEPTIONS = {
 KEYSTONE_CACERT = "keystone_juju_ca_cert.crt"
 KEYSTONE_REMOTE_CACERT = (
     "/usr/local/share/ca-certificates/{}".format(KEYSTONE_CACERT))
-KEYSTONE_LOCAL_CACERT = ("/tmp/{}".format(KEYSTONE_CACERT))
+KEYSTONE_LOCAL_CACERT = ("tests/{}".format(KEYSTONE_CACERT))
 
 
 def get_cacert():


### PR DESCRIPTION
At present the overcloud CACERT is copied to /tmp and as such it
is not possbile to run multiple tests at once without them
stepping on each other.

Store the copy in a path relative to where the test is executed,
in line with how the SSH keys are stored etc.

Fixes #331