### PR TITLE
Do not run API check on Ocata

### DIFF
--- a/zaza/openstack/charm_tests/ceilometer/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer/tests.py
@@ -101,7 +101,7 @@ class CeilometerTest(test_utils.OpenStackBaseTest):
 
     def test_400_api_connection(self):
         """Simple api calls to check service is up and responding."""
-        if self.current_release >= CeilometerTest.XENIAL_PIKE:
+        if self.current_release >= CeilometerTest.XENIAL_OCATA:
             logging.info('Skipping API checks as ceilometer api has been '
                          'removed')
             return


### PR DESCRIPTION
Since commit c98aa001f997d2cc149e0c64e81f0339a83adc50, there are some
missing changes.

This stops the API check on Ocata when gnocchi is in play. Gnocchi must
be in play for Ocata but heretofore has not been.