### PR TITLE
Fix paramiko.ssh_exception.BadAuthenticationType

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -773,7 +773,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             privkey='myprivkey')
         paramiko_mock.connect.assert_called_once_with(
             '10.0.0.10',
-            password='',
+            password=None,
             pkey='akey',
             username='bob')
 

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2401,7 +2401,7 @@ def ssh_command(username,
         ssh.connect(ip, username=username, password=password)
     else:
         key = paramiko.RSAKey.from_private_key(io.StringIO(privkey))
-        ssh.connect(ip, username=username, password='', pkey=key)
+        ssh.connect(ip, username=username, password=None, pkey=key)
     logging.info("Running {} on {}".format(command, vm_name))
     stdin, stdout, stderr = ssh.exec_command(command)
     if verify and callable(verify):


### PR DESCRIPTION
when SSHing to a new Ubuntu instance.

Note that paramiko still has a few issues around authentication:
https://github.com/paramiko/paramiko/pull/1106/files

This paramiko PR also shows that password='' isn't the same as
password=None