### PR TITLE
Wait for resolving update-status hook errors

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -521,7 +521,7 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
         zaza.model.resolve_units(
             application_name=self.application,
             erred_hook='update-status',
-            wait=True)
+            wait=True, timeout=180)
 
     def test_100_reboot_cluster_from_complete_outage(self):
         """Reboot cluster from complete outage.


### PR DESCRIPTION
The cold boot restart takes too long on update-status. Make the timeout
longer.