### PR TITLE
Stop assuming RegionOne in ceph-radosgw tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -622,7 +622,9 @@ class CephRGWTest(test_utils.OpenStackBaseTest):
                                     'multisite configuration')
         logging.info('Checking Swift REST API')
         keystone_session = zaza_openstack.get_overcloud_keystone_session()
-        region_name = 'RegionOne'
+        region_name = zaza_model.get_application_config(
+            self.application_name,
+            model_name=self.model_name)['region']['value']
         swift_client = zaza_openstack.get_swift_session_client(
             keystone_session,
             region_name,


### PR DESCRIPTION
Stop assuming RegionOne in ceph-radosgw tests and get the region
from the app config instead.