### PR TITLE
Add ceph_ready config step

### DIFF
--- a/zaza/openstack/charm_tests/ceph/setup.py
+++ b/zaza/openstack/charm_tests/ceph/setup.py
@@ -14,7 +14,23 @@
 
 """Setup for ceph-osd deployments."""
 
+import logging
+import zaza.model
+
 
 def basic_setup():
     """Run basic setup for ceph-osd."""
     pass
+
+
+def ceph_ready():
+    """Wait for ceph to be ready.
+
+    Wait for ceph to be ready. This is useful if the target_deploy_status in
+    the tests.yaml is expecting ceph to be in a blocked state. After ceph
+    has been unblocked the deploy may need to wait to be ceph to be ready.
+    """
+    logging.info("Waiting for ceph units to settle")
+    zaza.model.wait_for_application_states()
+    zaza.model.block_until_all_units_idle()
+    logging.info("Ceph units settled")

--- a/zaza/openstack/charm_tests/ceph/setup.py
+++ b/zaza/openstack/charm_tests/ceph/setup.py
@@ -28,7 +28,7 @@ def ceph_ready():
 
     Wait for ceph to be ready. This is useful if the target_deploy_status in
     the tests.yaml is expecting ceph to be in a blocked state. After ceph
-    has been unblocked the deploy may need to wait to be ceph to be ready.
+    has been unblocked the deploy may need to wait for ceph to be ready.
     """
     logging.info("Waiting for ceph units to settle")
     zaza.model.wait_for_application_states()


### PR DESCRIPTION
Add a ceph_ready config step which just checks that the ceph units
are in a 'active' 'Unit is Ready.*' state. This is useful when
encryption at rest is being used and the tests.yaml assumes that
the units are going to come up blocked. Once vault is ready the
tests then need to wait for the ceph units to become unblocked.