### PR TITLE
Tell horizon to use the "default" region

### DIFF
--- a/zaza/openstack/charm_tests/saml_mellon/tests.py
+++ b/zaza/openstack/charm_tests/saml_mellon/tests.py
@@ -72,12 +72,6 @@ class CharmKeystoneSAMLMellonTest(BaseKeystoneTest):
 
     def test_saml_mellon_redirects(self):
         """Validate the horizon -> keystone -> IDP redirects."""
-        if self.vip:
-            keystone_ip = self.vip
-        else:
-            unit = zaza.model.get_units(self.application_name)[0]
-            keystone_ip = unit.public_address
-
         horizon = "openstack-dashboard"
         horizon_vip = (zaza.model.get_application_config(horizon)
                        .get("vip").get("value"))

--- a/zaza/openstack/charm_tests/saml_mellon/tests.py
+++ b/zaza/openstack/charm_tests/saml_mellon/tests.py
@@ -93,7 +93,7 @@ class CharmKeystoneSAMLMellonTest(BaseKeystoneTest):
             proto = "http"
 
         url = "{}://{}/horizon/auth/login/".format(proto, horizon_ip)
-        region = "{}://{}:5000/v3".format(proto, keystone_ip)
+        region = "default"
         horizon_expect = ('<option value="samltest_mapped">'
                           'samltest.id</option>')
 


### PR DESCRIPTION
SAML Mellon tests have been broken on Focal. The handling of the region
selection behaves differently from bionic. Or it may be that bionic
accidentally was working by seeing a string as int 0.

Horizon has a "default" region which returns the keystone URL.