### PR TITLE
Fix the charm-upgrade tests as used by CoT

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
+++ b/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
@@ -88,7 +88,6 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             expected)
 
     def test_get_upgrade_groups(self):
-        # expected = collections.OrderedDict([
         expected = [
             ('Database Services', []),
             ('Stateful Services', []),
@@ -104,7 +103,6 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             expected)
 
     def test_get_series_upgrade_groups(self):
-        # expected = collections.OrderedDict([
         expected = [
             ('Database Services', ['mydb']),
             ('Stateful Services', []),

--- a/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
+++ b/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import copy
 import mock
 import pprint
@@ -89,12 +88,14 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             expected)
 
     def test_get_upgrade_groups(self):
-        expected = collections.OrderedDict([
+        # expected = collections.OrderedDict([
+        expected = [
+            ('Database Services', []),
             ('Stateful Services', []),
             ('Core Identity', []),
             ('Control Plane', ['cinder']),
             ('Data Plane', ['nova-compute']),
-            ('sweep_up', [])])
+            ('sweep_up', [])]
         actual = openstack_upgrade.get_upgrade_groups()
         pprint.pprint(expected)
         pprint.pprint(actual)
@@ -103,12 +104,14 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             expected)
 
     def test_get_series_upgrade_groups(self):
-        expected = collections.OrderedDict([
-            ('Stateful Services', ['mydb']),
+        # expected = collections.OrderedDict([
+        expected = [
+            ('Database Services', ['mydb']),
+            ('Stateful Services', []),
             ('Core Identity', []),
             ('Control Plane', ['cinder']),
             ('Data Plane', ['nova-compute']),
-            ('sweep_up', ['ntp'])])
+            ('sweep_up', ['ntp'])]
         actual = openstack_upgrade.get_series_upgrade_groups()
         pprint.pprint(expected)
         pprint.pprint(actual)

--- a/zaza/openstack/charm_tests/charm_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/charm_upgrade/tests.py
@@ -53,8 +53,11 @@ class FullCloudCharmUpgradeTest(unittest.TestCase):
         """Run charm upgrade."""
         self.lts.test_launch_small_instance()
         applications = zaza.model.get_status().applications
-        groups = upgrade_utils.get_charm_upgrade_groups()
-        for group_name, group in groups.items():
+        groups = upgrade_utils.get_charm_upgrade_groups(
+            extra_filters=[upgrade_utils._filter_etcd,
+                           upgrade_utils._filter_easyrsa,
+                           upgrade_utils._filter_memcached])
+        for group_name, group in groups:
             logging.info("About to upgrade {} ({})".format(group_name, group))
             for application, app_details in applications.items():
                 if application not in group:

--- a/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
@@ -73,11 +73,14 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
         workaround_script = None
         files = []
         applications = model.get_status().applications
-        for group_name, apps in upgrade_groups.items():
+        for group_name, apps in upgrade_groups:
             logging.info("About to upgrade {} from {} to {}".format(
                 group_name, from_series, to_series))
             upgrade_functions = []
-            if group_name in ["Stateful Services", "Data Plane", "sweep_up"]:
+            if group_name in ["Database Services",
+                              "Stateful Services",
+                              "Data Plane",
+                              "sweep_up"]:
                 logging.info("Going to upgrade {} unit by unit".format(apps))
                 upgrade_function = \
                     parallel_series_upgrade.serial_series_upgrade

--- a/zaza/openstack/charm_tests/series_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/tests.py
@@ -30,22 +30,6 @@ from zaza.openstack.utilities import (
 from zaza.openstack.charm_tests.nova.tests import LTSGuestCreateTest
 
 
-def _filter_easyrsa(app, app_config, model_name=None):
-    charm_name = upgrade_utils.extract_charm_name_from_url(app_config['charm'])
-    if "easyrsa" in charm_name:
-        logging.warn("Skipping series upgrade of easyrsa Bug #1850121")
-        return True
-    return False
-
-
-def _filter_etcd(app, app_config, model_name=None):
-    charm_name = upgrade_utils.extract_charm_name_from_url(app_config['charm'])
-    if "etcd" in charm_name:
-        logging.warn("Skipping series upgrade of easyrsa Bug #1850124")
-        return True
-    return False
-
-
 class SeriesUpgradeTest(unittest.TestCase):
     """Class to encapsulate Series Upgrade Tests."""
 
@@ -75,7 +59,7 @@ class SeriesUpgradeTest(unittest.TestCase):
                 continue
             if "etcd" in app_details["charm"]:
                 logging.warn(
-                    "Skipping series upgrade of easyrsa Bug #1850124")
+                    "Skipping series upgrade of etcd Bug #1850124")
                 continue
             charm_name = upgrade_utils.extract_charm_name_from_url(
                 app_details['charm'])
@@ -208,10 +192,11 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
         # Set Feature Flag
         os.environ["JUJU_DEV_FEATURE_FLAGS"] = "upgrade-series"
         upgrade_groups = upgrade_utils.get_series_upgrade_groups(
-            extra_filters=[_filter_etcd, _filter_easyrsa])
+            extra_filters=[upgrade_utils._filter_etcd,
+                           upgrade_utils._filter_easyrsa])
         applications = model.get_status().applications
         completed_machines = []
-        for group_name, group in upgrade_groups.items():
+        for group_name, group in upgrade_groups:
             logging.warn("About to upgrade {} ({})".format(group_name, group))
             upgrade_group = []
             for application, app_details in applications.items():


### PR DESCRIPTION
The biggest change is that the upgrade_groups() is a list of tuples ...
[()] ... rathern than a collections.OrderedDict().  This tends to make
more sense as they are processed in order and don't actually need to be
indexed.

Also excludes easyrsa (as it's not an upgrade target) and adds a
"Database Services" which upgrades mysql or percona FIRST before moving
on to rabbitmq and other stateful services.  This is because some charms
really need to talk to mysql if one of the other stateful services does
a relation changed hook.  This makes it more likely that the system will
ugprade correctly.