### PR TITLE
Ensure that octavia sets up application_name

### DIFF
--- a/zaza/openstack/charm_tests/octavia/setup.py
+++ b/zaza/openstack/charm_tests/octavia/setup.py
@@ -92,7 +92,7 @@ def configure_octavia():
     del test_config['target_deploy_status']['octavia']
 
     _singleton = zaza.openstack.charm_tests.test_utils.OpenStackBaseTest()
-    _singleton.setUpClass()
+    _singleton.setUpClass(application_name='octavia')
     with _singleton.config_change(cert_config, cert_config):
         # wait for configuration to be applied then return
         pass


### PR DESCRIPTION
When running in a deployment that is focused on bundles rather
than a specific charm, the Octavia setup can fail because there
is no configured charm_name in the tests.yaml. This change
ensures that the Octavia setup can continue.