### PR TITLE
Retry on failures to download Arista image

### DIFF
--- a/zaza/openstack/charm_tests/neutron_arista/setup.py
+++ b/zaza/openstack/charm_tests/neutron_arista/setup.py
@@ -45,9 +45,15 @@ def download_arista_image():
         if os.environ['TEST_ARISTA_IMAGE_REMOTE']:
             logging.info('Downloading Arista image from {}'
                          .format(os.environ['TEST_ARISTA_IMAGE_REMOTE']))
-            openstack_utils.download_image(
-                os.environ['TEST_ARISTA_IMAGE_REMOTE'],
-                os.environ['TEST_ARISTA_IMAGE_LOCAL'])
+
+            for attempt in tenacity.Retrying(
+                    stop=tenacity.stop_after_attempt(3),
+                    reraise=True):
+                with attempt:
+                    openstack_utils.download_image(
+                        os.environ['TEST_ARISTA_IMAGE_REMOTE'],
+                        os.environ['TEST_ARISTA_IMAGE_LOCAL'])
+
     except KeyError:
         # TEST_ARISTA_IMAGE_REMOTE isn't set, which means the image is already
         # available at TEST_ARISTA_IMAGE_LOCAL


### PR DESCRIPTION
In the pre-deploy step of our neutron-arista tests we download an
Arista image from our swift bucket. It sometimes fails when our CI
system is loaded. This patch adds a tenacity retry.