### PR TITLE
Make test_check_pool_types handle missing apps

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -818,8 +818,15 @@ class CheckPoolTypes(unittest.TestCase):
             ('cinder-ceph', 'cinder-ceph')]
         runtime_pool_details = zaza_ceph.get_ceph_pool_details()
         for app, pool_name in app_pools:
-            juju_pool_config = zaza_model.get_application_config(app).get(
-                'pool-type')
+            try:
+                app_config = zaza_model.get_application_config(app)
+            except KeyError:
+                logging.info(
+                    'Skipping pool check of %s, application %s not present',
+                    pool_name,
+                    app)
+                continue
+            juju_pool_config = app_config.get('pool-type')
             if juju_pool_config:
                 expected_pool_type = juju_pool_config['value']
             else:


### PR DESCRIPTION
Currently test_check_pool_types will fail when it tries to check
the corresponding pool type for an application that is not present
in the deployment, this patch changes the behaviour to skip missing
applications.