### PR TITLE
Fix series-upgrade tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiounittest
 async_generator
 boto3
-juju
+juju!=2.8.3  # blacklist 2.8.3 as it appears to have a connection bug
 juju_wait
 PyYAML<=4.2,>=3.0
 flake8>=2.2.4

--- a/zaza/openstack/charm_tests/series_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/tests.py
@@ -81,7 +81,7 @@ class SeriesUpgradeTest(unittest.TestCase):
                 logging.info(
                     "Running complete-cluster-series-upgrade action on leader")
                 model.run_action_on_leader(
-                    'rabbitmq-server',
+                    charm_name,
                     'complete-cluster-series-upgrade',
                     action_params={})
                 model.block_until_all_units_idle()
@@ -90,7 +90,7 @@ class SeriesUpgradeTest(unittest.TestCase):
                 logging.info(
                     "Running complete-cluster-series-upgrade action on leader")
                 model.run_action_on_leader(
-                    'mysql',
+                    charm_name,
                     'complete-cluster-series-upgrade',
                     action_params={})
                 model.block_until_all_units_idle()


### PR DESCRIPTION
A couple of changes here:

 * Ensure that the post-upgrade-hook runs BEFORE the config-changed to
   set the openstack-origin/source back to distro.  The former behaviour
   breaks keystone quite badly.
 * Ensure that the charm name is used, as discovered from the model, for
   rabbitmq-server and percona-cluster to cope with different bames for
   the application in the model vs the charm name from the charm-store.
 * Check whether the machine needs to be rebooted after the dist-upgrade
   (before the do-release-upgrade), and reboot the machine first.
   Otherwise, do-release-upgrade will fail.