### PR TITLE
Log resource cleanup failure and carry on, retry lb resource creation and various other retry fixes

### DIFF
--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -495,6 +495,11 @@ class OpenStackBaseTest(BaseCharmTest):
                         self.nova_client.servers,
                         server.id,
                         msg="server")
+        except AssertionError as e:
+            # Resource failed to be removed within the expected time frame,
+            # log this fact and carry on.
+            logging.warning('Gave up waiting for resource cleanup: "{}"'
+                            .format(str(e)))
         except AttributeError:
             # Test did not define self.RESOURCE_PREFIX, ignore.
             pass


### PR DESCRIPTION
Given the next action after resource cleanup often would be to destroy the whole deployment and continue with the next bundle I would argue we should just log the fact and carry on.

Also add retry handling for the individual lb resource creation code.

Fixes #417