### PR TITLE
Do not attempt to restore configuration when equal

### DIFF
--- a/unit_tests/charm_tests/test_utils.py
+++ b/unit_tests/charm_tests/test_utils.py
@@ -106,6 +106,24 @@ class TestBaseCharmTest(ut_utils.BaseTestCase):
             mock.call(),
             mock.call(),
         ])
+        # confirm operation where both default and alternate config passed in
+        # are the same. This is used to set config and not change it back.
+        self.set_application_config.reset_mock()
+        self.wait_for_agent_status.reset_mock()
+        self.wait_for_application_states.reset_mock()
+        self.reset_application_config.reset_mock()
+        with self.target.config_change(
+                alterna_config, alterna_config, application_name='anApp'):
+            self.set_application_config.assert_called_once_with(
+                'anApp', alterna_config, model_name='aModel')
+            # we want to assert these not to be called after yield
+            self.set_application_config.reset_mock()
+            self.wait_for_agent_status.reset_mock()
+            self.wait_for_application_states.reset_mock()
+        self.assertFalse(self.set_application_config.called)
+        self.assertFalse(self.reset_application_config.called)
+        self.assertFalse(self.wait_for_agent_status.called)
+        self.assertFalse(self.wait_for_application_states.called)
 
 
 class TestOpenStackBaseTest(ut_utils.BaseTestCase):

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -259,6 +259,10 @@ class BaseCharmTest(unittest.TestCase):
             model.reset_application_config(application_name,
                                            alternate_config.keys(),
                                            model_name=self.model_name)
+        elif default_config == alternate_config:
+            logging.debug('default_config == alternate_config, not attempting '
+                          ' to restore configuration')
+            return
         else:
             logging.debug('Restoring charm setting to {}'
                           .format(default_config))


### PR DESCRIPTION
The fix for the config_change helpers short cut on config restore
in c5a3f832d014b28dd997356416af3ca082434d4c introduced a
regression for consumers that use the helper to set but not
restore config.

Re-introduce the shortcut when the caller passes in equal settings
for default and alternate configuration.

Fixes #427