### PR TITLE
Only configure private Neutron CIDR if it is configured

### DIFF
--- a/unit_tests/charm_tests/test_tempest.py
+++ b/unit_tests/charm_tests/test_tempest.py
@@ -42,7 +42,7 @@ class TestTempestSetup(unittest.TestCase):
             'TEST_GATEWAY': 'test',
             'TEST_CIDR_EXT': 'test',
             'TEST_FIP_RANGE': 'test',
-            'TEST_NAMESERVER': 'test',
+            'TEST_NAME_SERVER': 'test',
             'TEST_CIDR_PRIV': 'test',
         }
         tempest_setup.add_environment_var_config(ctxt, ['neutron'])
@@ -55,7 +55,7 @@ class TestTempestSetup(unittest.TestCase):
         ctxt = {}
         get_deployment_context.return_value = {
             'TEST_GATEWAY': 'test',
-            'TEST_NAMESERVER': 'test',
+            'TEST_NAME_SERVER': 'test',
             'TEST_CIDR_PRIV': 'test',
         }
         with self.assertRaises(Exception) as context:

--- a/zaza/openstack/charm_tests/tempest/setup.py
+++ b/zaza/openstack/charm_tests/tempest/setup.py
@@ -26,9 +26,11 @@ import zaza.openstack.charm_tests.glance.setup as glance_setup
 
 SETUP_ENV_VARS = {
     'neutron': ['TEST_GATEWAY', 'TEST_CIDR_EXT', 'TEST_FIP_RANGE',
-                'TEST_NAMESERVER', 'TEST_CIDR_PRIV'],
+                'TEST_NAME_SERVER', 'TEST_CIDR_PRIV'],
     'swift': ['TEST_SWIFT_IP'],
 }
+
+IGNORABLE_VARS = ['TEST_CIDR_PRIV']
 
 TEMPEST_FLAVOR_NAME = 'm1.tempest'
 TEMPEST_ALT_FLAVOR_NAME = 'm2.tempest'
@@ -198,7 +200,8 @@ def add_environment_var_config(ctxt, services):
                 if value:
                     ctxt[var.lower()] = value
                 else:
-                    missing_vars.append(var)
+                    if var not in IGNORABLE_VARS:
+                        missing_vars.append(var)
     if missing_vars:
         raise ValueError(
             ("Environment variables [{}] must all be set to run this"

--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v2.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v2.j2
@@ -52,7 +52,9 @@ http_image = http://{{ test_swift_ip }}:80/swift/v1/images/cirros-0.3.4-x86_64-u
 
 {% if 'neutron' in enabled_services %}
 [network]
+{% if test_cidr_priv %}
 project_network_cidr = {{ test_cidr_priv }}
+{% endif %}
 public_network_id = {{ ext_net }}
 dns_servers = {{ test_nameserver }}
 project_networks_reachable = false

--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v2.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v2.j2
@@ -56,7 +56,7 @@ http_image = http://{{ test_swift_ip }}:80/swift/v1/images/cirros-0.3.4-x86_64-u
 project_network_cidr = {{ test_cidr_priv }}
 {% endif %}
 public_network_id = {{ ext_net }}
-dns_servers = {{ test_nameserver }}
+dns_servers = {{ test_name_server }}
 project_networks_reachable = false
 
 [network-feature-enabled]

--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -58,7 +58,7 @@ http_image = http://{{ test_swift_ip }}:80/swift/v1/images/cirros-0.3.4-x86_64-u
 project_network_cidr = {{ test_cidr_priv }}
 {% endif %}
 public_network_id = {{ ext_net }}
-dns_servers = {{ test_nameserver }}
+dns_servers = {{ test_name_server }}
 project_networks_reachable = false
 floating_network_name = {{ ext_net }}
 

--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -54,7 +54,9 @@ http_image = http://{{ test_swift_ip }}:80/swift/v1/images/cirros-0.3.4-x86_64-u
 
 {% if 'neutron' in enabled_services %}
 [network]
+{% if test_cidr_priv %}
 project_network_cidr = {{ test_cidr_priv }}
+{% endif %}
 public_network_id = {{ ext_net }}
 dns_servers = {{ test_nameserver }}
 project_networks_reachable = false


### PR DESCRIPTION
This change also updates the TEST_NAMESERVER to use the correct environment variable to match what is set in Ubuntu's OpenStack CI