### PR TITLE
Update vault tests with new status message

### DIFF
--- a/zaza/openstack/charm_tests/vault/tests.py
+++ b/zaza/openstack/charm_tests/vault/tests.py
@@ -153,7 +153,8 @@ class VaultTest(BaseVaultTest):
             allowed_domains='openstack.local')
 
         test_config = lifecycle_utils.get_charm_config()
-        del test_config['target_deploy_status']['vault']
+        test_config['target_deploy_status']['vault'][
+            'workload-status-message'] = 'New version of vault installed'
         zaza.model.block_until_file_has_contents(
             'keystone',
             zaza.openstack.utilities.openstack.KEYSTONE_REMOTE_CACERT,


### PR DESCRIPTION
New status message is introduced for vault charm as part of
LP bug #1895577 [1]. The new status message has been added to the
list of workload status messages the test cases will wait for.

Vault charm changes: https://review.opendev.org/#/c/754267/

[1] https://bugs.launchpad.net/vault-charm/+bug/1895577