### PR TITLE
Add python-ironicclient to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ install_require = [
     'python-barbicanclient>=4.0.1,<5.0.0',
     'python-designateclient>=1.5,<3.0.0',
     'python-heatclient<2.0.0',
+    'python-ironicclient',
     'python-glanceclient<3.0.0',
     'python-keystoneclient<3.22.0',
     'python-manilaclient<2.0.0',


### PR DESCRIPTION
This package is already added to requirements.txt, but for some reason it's not being installed. Adding it to setup.py with the other dependencies.