### PR TITLE
Concurrent series upgrade updates

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_parallel_series_upgrade.py
+++ b/unit_tests/utilities/test_zaza_utilities_parallel_series_upgrade.py
@@ -182,6 +182,8 @@ class TestParallelSeriesUpgrade(AioTestCase):
         self.model.async_wait_for_unit_idle = mock.AsyncMock()
         self.async_run_on_machine = mock.AsyncMock()
         self.model.async_run_on_machine = self.async_run_on_machine
+        self.model.async_block_until_units_on_machine_are_idle = \
+            mock.AsyncMock()
 
     @mock.patch.object(upgrade_utils.cl_utils, 'get_class')
     async def test_run_post_application_upgrade_functions(

--- a/unit_tests/utilities/test_zaza_utilities_parallel_series_upgrade.py
+++ b/unit_tests/utilities/test_zaza_utilities_parallel_series_upgrade.py
@@ -494,7 +494,13 @@ class TestParallelSeriesUpgrade(AioTestCase):
         mock_remove_confdef_file.assert_called_once_with('1')
         mock_add_confdef_file.assert_called_once_with('1')
 
-    async def test_maybe_pause_things_primary(self):
+    @mock.patch("asyncio.gather")
+    async def test_maybe_pause_things_primary(self, mock_gather):
+        async def _gather(*args):
+            for f in args:
+                await f
+
+        mock_gather.side_effect = _gather
         await upgrade_utils.maybe_pause_things(
             FAKE_STATUS,
             ['app/1', 'app/2'],
@@ -505,7 +511,13 @@ class TestParallelSeriesUpgrade(AioTestCase):
             mock.call('app/2', "pause", action_params={}),
         ])
 
-    async def test_maybe_pause_things_subordinates(self):
+    @mock.patch("asyncio.gather")
+    async def test_maybe_pause_things_subordinates(self, mock_gather):
+        async def _gather(*args):
+            for f in args:
+                await f
+
+        mock_gather.side_effect = _gather
         await upgrade_utils.maybe_pause_things(
             FAKE_STATUS,
             ['app/1', 'app/2'],
@@ -516,7 +528,13 @@ class TestParallelSeriesUpgrade(AioTestCase):
             mock.call('app-hacluster/2', "pause", action_params={}),
         ])
 
-    async def test_maybe_pause_things_all(self):
+    @mock.patch("asyncio.gather")
+    async def test_maybe_pause_things_all(self, mock_gather):
+        async def _gather(*args):
+            for f in args:
+                await f
+
+        mock_gather.side_effect = _gather
         await upgrade_utils.maybe_pause_things(
             FAKE_STATUS,
             ['app/1', 'app/2'],

--- a/zaza/openstack/charm_tests/charm_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/charm_upgrade/tests.py
@@ -35,6 +35,7 @@ class FullCloudCharmUpgradeTest(unittest.TestCase):
         """Run setup for Charm Upgrades."""
         cli_utils.setup_logging()
         cls.lts = LTSGuestCreateTest()
+        cls.lts.setUpClass()
         cls.target_charm_namespace = '~openstack-charmers-next'
 
     def get_upgrade_url(self, charm_url):

--- a/zaza/openstack/charm_tests/mysql/utils.py
+++ b/zaza/openstack/charm_tests/mysql/utils.py
@@ -19,8 +19,17 @@ import zaza.model as model
 
 async def complete_cluster_series_upgrade():
     """Run the complete-cluster-series-upgrade action on the lead unit."""
-    # TODO: Make this work across either mysql or percona-cluster names
-    await model.async_run_action_on_leader(
-        'mysql',
-        'complete-cluster-series-upgrade',
-        action_params={})
+    # Note that some models use mysql as the application name, and other's use
+    # percona-cluster.  Try mysql first, and if it doesn't exist, then try
+    # percona-cluster instead.
+    try:
+        await model.async_run_action_on_leader(
+            'mysql',
+            'complete-cluster-series-upgrade',
+            action_params={})
+    except KeyError:
+        await model.async_run_action_on_leader(
+            'percona-cluster',
+            'complete-cluster-series-upgrade',
+            action_params={})
+

--- a/zaza/openstack/charm_tests/mysql/utils.py
+++ b/zaza/openstack/charm_tests/mysql/utils.py
@@ -32,4 +32,3 @@ async def complete_cluster_series_upgrade():
             'percona-cluster',
             'complete-cluster-series-upgrade',
             action_params={})
-

--- a/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
@@ -96,7 +96,7 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
                 upgrade_function = \
                     parallel_series_upgrade.parallel_series_upgrade
 
-            # allow up to 3 parallel upgrades at a time.  This is to limit the
+            # allow up to 4 parallel upgrades at a time.  This is to limit the
             # amount of data/calls that asyncio is handling as it's gets
             # unstable if all the applications are done at the same time.
             sem = asyncio.Semaphore(4)

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -83,7 +83,7 @@ async def mojo_or_default_unseal_by_unit():
     try:
         await mojo_unseal_by_unit()
     except zaza_exceptions.CACERTNotFound:
-        await unseal_but_unit()
+        await unseal_by_unit()
 
 
 def mojo_unseal_by_unit():
@@ -114,7 +114,7 @@ async def async_mojo_or_default_unseal_by_unit():
     try:
         await async_mojo_unseal_by_unit()
     except zaza_exceptions.CACERTNotFound:
-        await async_unseal_but_unit()
+        await async_unseal_by_unit()
 
 
 async def async_mojo_unseal_by_unit():

--- a/zaza/openstack/utilities/parallel_series_upgrade.py
+++ b/zaza/openstack/utilities/parallel_series_upgrade.py
@@ -58,7 +58,7 @@ def app_config(charm_name):
     }
     exceptions = {
         'rabbitmq-server': {
-            'origin': 'source',
+            'origin': None,  # NOTE: AJK disable config-changed on rabbitmq-server due to bug: #1896520
             'pause_non_leader_subordinate': False,
             'post_application_upgrade_functions': [
                 ('zaza.openstack.charm_tests.rabbitmq_server.utils.'
@@ -191,47 +191,76 @@ async def parallel_series_upgrade(
     status = (await model.async_get_status()).applications[application]
     logging.info(
         "Configuring leader / non leaders for {}".format(application))
-    leader, non_leaders = get_leader_and_non_leaders(status)
-    for leader_name, leader_unit in leader.items():
+    leaders, non_leaders = get_leader_and_non_leaders(status)
+    for leader_unit in leaders.values():
         leader_machine = leader_unit["machine"]
-        leader = leader_name
-    machines = [
-        unit["machine"] for name, unit
-        in non_leaders.items()
-        if unit['machine'] not in completed_machines]
+    machines = [unit["machine"] for name, unit in non_leaders.items()
+                if unit['machine'] not in completed_machines]
 
     await maybe_pause_things(
         status,
         non_leaders,
         pause_non_leader_subordinate,
         pause_non_leader_primary)
-    await series_upgrade_utils.async_set_series(
-        application, to_series=to_series)
-    app_idle = [
+    # wait for the entire application set to be idle before starting upgrades
+    await asyncio.gather(*[
         model.async_wait_for_unit_idle(unit, include_subordinates=True)
-        for unit in status["units"]
-    ]
-    await asyncio.gather(*app_idle)
+        for unit in status["units"]])
     await prepare_series_upgrade(leader_machine, to_series=to_series)
-    prepare_group = [
-        prepare_series_upgrade(machine, to_series=to_series)
-        for machine in machines]
-    await asyncio.gather(*prepare_group)
+    await asyncio.gather(*[
+        wait_for_idle_then_prepare_series_upgrade(
+            machine, to_series=to_series)
+        for machine in machines])
     if leader_machine not in completed_machines:
         machines.append(leader_machine)
-    upgrade_group = [
+    await asyncio.gather(*[
         series_upgrade_machine(
             machine,
             origin=origin,
             application=application,
             files=files, workaround_script=workaround_script,
             post_upgrade_functions=post_upgrade_functions)
-        for machine in machines
-    ]
-    await asyncio.gather(*upgrade_group)
+        for machine in machines])
     completed_machines.extend(machines)
+    await series_upgrade_utils.async_set_series(
+        application, to_series=to_series)
     await run_post_application_upgrade_functions(
         post_application_upgrade_functions)
+
+
+async def wait_for_idle_then_prepare_series_upgrade(
+        machine, to_series, model_name=None):
+    """Wait for the units to idle the do prepare_series_upgrade.
+
+    We need to be sure that all the units are idle prior to actually calling
+    prepare_series_upgrade() as otherwise the call will fail.  It has to be
+    checked because when the leader is paused it may kick off relation hooks in
+    the other units in an HA group.
+
+    :param machine: the machine that is going to be prepared
+    :type machine: str
+    :param to_series: The series to which to upgrade
+    :type to_series: str
+    :param model_name: Name of model to query.
+    :type model_name: str
+    """
+    # get all the units on this machine
+    # _status = await model.async_get_status(model_name=model_name)
+    # units = []
+    # for _, app_data in _status["applications"].items():
+        # if app_data["subordinate-to"]:
+            # continue
+        # for unit, unit_data in app_data["units"].items():
+            # if unit_data["machine"] == machine:
+                # units.append(unit)
+    # # TODO: this should be a test on all units being idle at the same time, not
+    # # just eventually!!!
+    # await asyncio.gather(*[
+        # model.async_wait_for_unit_idle(unit, include_subordinates=True)
+        # for unit in units])
+    await model.async_block_until_units_on_machine_are_idle(
+        machine, model_name=model_name)
+    await prepare_series_upgrade(machine, to_series=to_series)
 
 
 async def serial_series_upgrade(
@@ -381,17 +410,16 @@ async def series_upgrade_machine(
     :returns: None
     :rtype: None
     """
-    logging.info(
-        "About to series-upgrade ({})".format(machine))
+    logging.info("About to series-upgrade ({})".format(machine))
     await run_pre_upgrade_functions(machine, pre_upgrade_functions)
     await add_confdef_file(machine)
     await async_dist_upgrade(machine)
     await async_do_release_upgrade(machine)
     await remove_confdef_file(machine)
     await reboot(machine)
+    await series_upgrade_utils.async_complete_series_upgrade(machine)
     if origin:
         await os_utils.async_set_origin(application, origin)
-    await series_upgrade_utils.async_complete_series_upgrade(machine)
     await run_post_upgrade_functions(post_upgrade_functions)
 
 
@@ -541,14 +569,14 @@ async def prepare_series_upgrade(machine, to_series):
     NOTE: This is a new feature in juju behind a feature flag and not yet in
     libjuju.
     export JUJU_DEV_FEATURE_FLAGS=upgrade-series
-    :param machine_num: Machine number
-    :type machine_num: str
+    :param machine: Machine number
+    :type machine: str
     :param to_series: The series to which to upgrade
     :type to_series: str
     :returns: None
     :rtype: None
     """
-    logging.info("Preparing series upgrade for: {}".format(machine))
+    logging.info("Preparing series upgrade for: %s", machine)
     await series_upgrade_utils.async_prepare_series_upgrade(
         machine, to_series=to_series)
 
@@ -564,9 +592,8 @@ async def reboot(machine):
     try:
         await model.async_run_on_machine(machine, 'sudo init 6 & exit')
         # await run_on_machine(unit, "sudo reboot && exit")
-    except subprocess.CalledProcessError as e:
-        logging.warn("Error doing reboot: {}".format(e))
-        pass
+    except subprocess.CalledProcessError as error:
+        logging.warning("Error doing reboot: %s", error)
 
 
 async def async_dist_upgrade(machine):
@@ -577,16 +604,31 @@ async def async_dist_upgrade(machine):
     :returns: None
     :rtype: None
     """
-    logging.info('Updating package db ' + machine)
+    logging.info('Updating package db %s', machine)
     update_cmd = 'sudo apt-get update'
     await model.async_run_on_machine(machine, update_cmd)
 
-    logging.info('Updating existing packages ' + machine)
+    logging.info('Updating existing packages %s', machine)
     dist_upgrade_cmd = (
         """yes | sudo DEBIAN_FRONTEND=noninteractive apt-get --assume-yes """
         """-o "Dpkg::Options::=--force-confdef" """
         """-o "Dpkg::Options::=--force-confold" dist-upgrade""")
     await model.async_run_on_machine(machine, dist_upgrade_cmd)
+    rdict = await model.async_run_on_machine(
+        machine,
+        "cat /var/run/reboot-required || true")
+    if "Stdout" in rdict and "restart" in rdict["Stdout"].lower():
+        logging.info("dist-upgrade required reboot machine: %s", machine)
+        await reboot(machine)
+        logging.info("Waiting for machine to come back afer reboot: %s",
+                     machine)
+        await model.async_block_until_file_missing_on_machine(
+            machine, "/var/run/reboot-required")
+        logging.info("Waiting for machine idleness on %s", machine)
+        await asyncio.sleep(5.0)
+        await model.async_block_until_units_on_machine_are_idle(machine)
+        # TODO: change this to wait on units on the machine
+        # await model.async_block_until_all_units_idle()
 
 
 async def async_do_release_upgrade(machine):
@@ -597,7 +639,7 @@ async def async_do_release_upgrade(machine):
     :returns: None
     :rtype: None
     """
-    logging.info('Upgrading ' + machine)
+    logging.info('Upgrading %s', machine)
     do_release_upgrade_cmd = (
         'yes | sudo DEBIAN_FRONTEND=noninteractive '
         'do-release-upgrade -f DistUpgradeViewNonInteractive')

--- a/zaza/openstack/utilities/series_upgrade.py
+++ b/zaza/openstack/utilities/series_upgrade.py
@@ -884,7 +884,7 @@ def dist_upgrade(unit_name):
         """-o "Dpkg::Options::=--force-confdef" """
         """-o "Dpkg::Options::=--force-confold" dist-upgrade""")
     model.run_on_unit(unit_name, dist_upgrade_cmd)
-    rdict = model.run_on_unit(unit_name, "cat /var/run/reboot-required")
+    rdict = model.run_on_unit(unit_name, "cat /var/run/reboot-required || true")
     if "Stdout" in rdict and "restart" in rdict["Stdout"].lower():
         logging.info("dist-upgrade required reboot {}".format(unit_name))
         os_utils.reboot(unit_name)
@@ -919,8 +919,8 @@ async def async_dist_upgrade(unit_name):
         """-o "Dpkg::Options::=--force-confdef" """
         """-o "Dpkg::Options::=--force-confold" dist-upgrade""")
     await model.async_run_on_unit(unit_name, dist_upgrade_cmd)
-    rdict = await model.async_run_on_unit(unit_name,
-                                          "cat /var/run/reboot-required")
+    rdict = await model.async_run_on_unit(
+        unit_name, "cat /var/run/reboot-required || true")
     if "Stdout" in rdict and "restart" in rdict["Stdout"].lower():
         logging.info("dist-upgrade required reboot {}".format(unit_name))
         await os_utils.async_reboot(unit_name)

--- a/zaza/openstack/utilities/series_upgrade.py
+++ b/zaza/openstack/utilities/series_upgrade.py
@@ -884,7 +884,8 @@ def dist_upgrade(unit_name):
         """-o "Dpkg::Options::=--force-confdef" """
         """-o "Dpkg::Options::=--force-confold" dist-upgrade""")
     model.run_on_unit(unit_name, dist_upgrade_cmd)
-    rdict = model.run_on_unit(unit_name, "cat /var/run/reboot-required || true")
+    rdict = model.run_on_unit(unit_name,
+                              "cat /var/run/reboot-required || true")
     if "Stdout" in rdict and "restart" in rdict["Stdout"].lower():
         logging.info("dist-upgrade required reboot {}".format(unit_name))
         os_utils.reboot(unit_name)


### PR DESCRIPTION
Changes to the parallel series upgrade tests to make them work more efficiently.

* Uses a semaphore to limit the number of applications that are upgraded in parallel.
* Changes the detection of idle machines to just the application that is being upgraded to increase parallelism of the series upgrade.
* A few improvements in code layout.