### PR TITLE
Fix BlueStoreCompressionCharmOperation on Victoria

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -881,9 +881,7 @@ class BlueStoreCompressionCharmOperation(test_utils.BaseCharmTest):
     def setUpClass(cls):
         """Perform class one time initialization."""
         super(BlueStoreCompressionCharmOperation, cls).setUpClass()
-        cls.current_release = zaza_openstack.get_os_release(
-            zaza_openstack.get_current_os_release_pair(
-                application='ceph-mon'))
+        cls.current_release = zaza_openstack.get_os_release()
         cls.bionic_rocky = zaza_openstack.get_os_release('bionic_rocky')
 
     def setUp(self):


### PR DESCRIPTION
Supersedes #467 

CI validation: 
- https://review.opendev.org/c/openstack/charm-ceph-fs/+/761544
- https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/761548

Before this fix, the test tried to determine the OpenStack
release based on the ceph-mon charm. Unfortunately Ceph has
the same version on Ussuri and Victoria. As a consequence
the test would wrongly conclude that it's testing against
"groovy_ussuri", which isn't a valid Ubuntu/OpenStack pair.

With this fix, the test now determines the OpenStack
release based on the keystone charm, with which we are able
to tell Ussuri and Victoria apart. This test class is being
run against the following charm functional tests at the
moment, which all have a keystone charm in their test
bundles: nova-compute, cinder-ceph, glance, ceph-fs,
ceph-radosgw and gnocchi.