### PR TITLE
Adjust tests after rework of the 'service' action

### DIFF
--- a/zaza/openstack/charm_tests/ceph/osd/tests.py
+++ b/zaza/openstack/charm_tests/ceph/osd/tests.py
@@ -156,8 +156,8 @@ class ServiceTest(unittest.TestCase):
 
         This ensures that the environment is ready for the next tests.
         """
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'service',
-                                       action_params={'start': 'all'},
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
+                                       action_params={'disks': 'all'},
                                        raise_on_failure=True)
 
     @property
@@ -186,16 +186,16 @@ class ServiceTest(unittest.TestCase):
 
         logging.info("Running 'service stop=all' action on {} "
                      "unit".format(self.TESTED_UNIT))
-        zaza_model.run_action_on_units([self.TESTED_UNIT], 'service',
-                                       action_params={'stop': 'all'})
+        zaza_model.run_action_on_units([self.TESTED_UNIT], 'stop',
+                                       action_params={'disks': 'all'})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='stopped')
 
         logging.info("Running 'service start=all' action on {} "
                      "unit".format(self.TESTED_UNIT))
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'service',
-                                       action_params={'start': 'all'})
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
+                                       action_params={'disks': 'all'})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='running')
@@ -208,16 +208,16 @@ class ServiceTest(unittest.TestCase):
 
         logging.info("Running 'service stop={}' action on {} "
                      "unit".format(action_params, self.TESTED_UNIT))
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'service',
-                                       action_params={'stop': action_params})
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'stop',
+                                       action_params={'disks': action_params})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='stopped')
 
         logging.info("Running 'service start={}' action on {} "
                      "unit".format(action_params, self.TESTED_UNIT))
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'service',
-                                       action_params={'start': action_params})
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
+                                       action_params={'disks': action_params})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='running')
@@ -236,8 +236,8 @@ class ServiceTest(unittest.TestCase):
         logging.info("Running 'service stop={} on {} "
                      "unit".format(to_stop.id, self.TESTED_UNIT))
 
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'service',
-                                       action_params={'stop': to_stop.id})
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'stop',
+                                       action_params={'disks': to_stop.id})
 
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=[to_stop.name, ],
@@ -269,8 +269,8 @@ class ServiceTest(unittest.TestCase):
         logging.info("Running 'service start={} on {} "
                      "unit".format(to_start.id, self.TESTED_UNIT))
 
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'service',
-                                       action_params={'start': to_start.id})
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
+                                       action_params={'disks': to_start.id})
 
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=[to_start.name, ],

--- a/zaza/openstack/charm_tests/ceph/osd/tests.py
+++ b/zaza/openstack/charm_tests/ceph/osd/tests.py
@@ -157,7 +157,7 @@ class ServiceTest(unittest.TestCase):
         This ensures that the environment is ready for the next tests.
         """
         zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                       action_params={'disks': 'all'},
+                                       action_params={'osds': 'all'},
                                        raise_on_failure=True)
 
     @property
@@ -187,7 +187,7 @@ class ServiceTest(unittest.TestCase):
         logging.info("Running 'service stop=all' action on {} "
                      "unit".format(self.TESTED_UNIT))
         zaza_model.run_action_on_units([self.TESTED_UNIT], 'stop',
-                                       action_params={'disks': 'all'})
+                                       action_params={'osds': 'all'})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='stopped')
@@ -195,7 +195,7 @@ class ServiceTest(unittest.TestCase):
         logging.info("Running 'service start=all' action on {} "
                      "unit".format(self.TESTED_UNIT))
         zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                       action_params={'disks': 'all'})
+                                       action_params={'osds': 'all'})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='running')
@@ -209,7 +209,7 @@ class ServiceTest(unittest.TestCase):
         logging.info("Running 'service stop={}' action on {} "
                      "unit".format(action_params, self.TESTED_UNIT))
         zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'stop',
-                                       action_params={'disks': action_params})
+                                       action_params={'osds': action_params})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='stopped')
@@ -217,7 +217,7 @@ class ServiceTest(unittest.TestCase):
         logging.info("Running 'service start={}' action on {} "
                      "unit".format(action_params, self.TESTED_UNIT))
         zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                       action_params={'disks': action_params})
+                                       action_params={'osds': action_params})
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=service_list,
                          target_status='running')
@@ -237,7 +237,7 @@ class ServiceTest(unittest.TestCase):
                      "unit".format(to_stop.id, self.TESTED_UNIT))
 
         zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'stop',
-                                       action_params={'disks': to_stop.id})
+                                       action_params={'osds': to_stop.id})
 
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=[to_stop.name, ],
@@ -270,7 +270,7 @@ class ServiceTest(unittest.TestCase):
                      "unit".format(to_start.id, self.TESTED_UNIT))
 
         zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                       action_params={'disks': to_start.id})
+                                       action_params={'osds': to_start.id})
 
         wait_for_service(unit_name=self.TESTED_UNIT,
                          services=[to_start.name, ],


### PR DESCRIPTION
Former 'service' action was reworked into two standalone actions `start` and `stop`. This required slight change in the tests to account for the change of the way in which are the actions called.

ceph-osd code review: https://review.opendev.org/c/openstack/charm-ceph-osd/+/756704/