### PR TITLE
Allow an app to be set when calling get_os_release

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -908,6 +908,14 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         release_comp = xenial_queens > xenial_mitaka
         self.assertTrue(release_comp)
 
+        # Check specifying an application
+        self._get_os_rel_pair.reset_mock()
+        self._get_os_rel_pair.return_value = 'xenial_mitaka'
+        expected = 4
+        result = openstack_utils.get_os_release(application='myapp')
+        self.assertEqual(expected, result)
+        self._get_os_rel_pair.assert_called_once_with(application='myapp')
+
     def test_get_keystone_api_version(self):
         self.patch_object(openstack_utils, "get_current_os_versions")
         self.patch_object(openstack_utils, "get_application_config_option")

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1602,15 +1602,19 @@ def get_current_os_release_pair(application='keystone'):
     return '{}_{}'.format(series, os_version)
 
 
-def get_os_release(release_pair=None):
+def get_os_release(release_pair=None, application=None):
     """Return index of release in OPENSTACK_RELEASES_PAIRS.
 
+    :param release_pair: OpenStack release pair eg 'focal_ussuri'
+    :type release_pair: string
+    :param application: Name of application to derive release pair from.
+    :type application: string
     :returns: Index of the release
     :rtype: int
     :raises: exceptions.ReleasePairNotFound
     """
     if release_pair is None:
-        release_pair = get_current_os_release_pair()
+        release_pair = get_current_os_release_pair(application=application)
     try:
         index = OPENSTACK_RELEASES_PAIRS.index(release_pair)
     except ValueError:


### PR DESCRIPTION
Ceph deployments may not contain a keystone service which causes
calls to get_os_release to fail as it calls get_current_os_release_pair
without sepecifying an application (keystone is the default).