### PR TITLE
Use ceph-mon to check ceph version not keystone

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -881,7 +881,8 @@ class BlueStoreCompressionCharmOperation(test_utils.BaseCharmTest):
     def setUpClass(cls):
         """Perform class one time initialization."""
         super(BlueStoreCompressionCharmOperation, cls).setUpClass()
-        cls.current_release = zaza_openstack.get_os_release()
+        cls.current_release = zaza_openstack.get_os_release(
+            application='ceph-mon')
         cls.bionic_rocky = zaza_openstack.get_os_release('bionic_rocky')
 
     def setUp(self):

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -881,8 +881,13 @@ class BlueStoreCompressionCharmOperation(test_utils.BaseCharmTest):
     def setUpClass(cls):
         """Perform class one time initialization."""
         super(BlueStoreCompressionCharmOperation, cls).setUpClass()
+        release_application = 'keystone'
+        try:
+            zaza_model.get_application(release_application)
+        except KeyError:
+            release_application = 'ceph-mon'
         cls.current_release = zaza_openstack.get_os_release(
-            application='ceph-mon')
+            application=release_application)
         cls.bionic_rocky = zaza_openstack.get_os_release('bionic_rocky')
 
     def setUp(self):


### PR DESCRIPTION
The test class BlueStoreCompressionCharmOperation gates tests on
whether the ceph release is mimic or newer but it uses the
keystone application to calculate the currently deployed version.
This PR switches the test class to ceck the version of ceph-mon
instead which makes more sense and the keystone application may
not always present in a ceph deployment.