### PR TITLE
nova: Conditional security checklist based on presence of vault

### DIFF
--- a/zaza/openstack/charm_tests/nova/tests.py
+++ b/zaza/openstack/charm_tests/nova/tests.py
@@ -495,17 +495,24 @@ class SecurityTests(test_utils.OpenStackBaseTest):
         # Changes fixing the below expected failures will be made following
         # this initial work to get validation in. There will be bugs targeted
         # to each one and resolved independently where possible.
-
         expected_failures = [
-            'is-volume-encryption-enabled',
-            'validate-uses-tls-for-glance',
-            'validate-uses-tls-for-keystone',
         ]
         expected_passes = [
             'validate-file-ownership',
             'validate-file-permissions',
             'validate-uses-keystone',
         ]
+        tls_checks = [
+            'validate-uses-tls-for-glance',
+            'validate-uses-tls-for-keystone',
+        ]
+        if zaza.model.get_relation_id(
+                'nova-cloud-controller',
+                'vault',
+                remote_interface_name='certificates'):
+            expected_passes.extend(tls_checks)
+        else:
+            expected_failures.extend(tls_checks)
 
         for unit in zaza.model.get_units(self.application_name,
                                          model_name=self.model_name):
@@ -519,4 +526,4 @@ class SecurityTests(test_utils.OpenStackBaseTest):
                     action_params={}),
                 expected_passes,
                 expected_failures,
-                expected_to_pass=False)
+                expected_to_pass=not len(expected_failures))


### PR DESCRIPTION
The current test expects Nova to never have TLS connections, let's
expect them to be there whenever vault is present.

Remove the 'is-volume-encryption-enabled' assertion as it is not
a property of the Nova security checks. This was previously masked
by the fact that action would always fail due to TLS tests not
being enabled for any bundles.