### PR TITLE
Handle change of CA cert.

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -1392,7 +1392,7 @@ class TestAsyncOpenstackUtils(ut_utils.AioTestCase):
 
         class AsyncContextManagerMock(test_mock):
             async def __aenter__(self):
-                yield model_mock
+                return self
 
             async def __aexit__(self, *args):
                 pass

--- a/unit_tests/utilities/test_zaza_utilities_parallel_series_upgrade.py
+++ b/unit_tests/utilities/test_zaza_utilities_parallel_series_upgrade.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import mock
 import sys
 import unittest
@@ -139,28 +138,7 @@ class Test_ParallelSeriesUpgradeSync(ut_utils.BaseTestCase):
         self.assertEqual(expected, config)
 
 
-class AioTestCase(ut_utils.BaseTestCase):
-    def __init__(self, methodName='runTest', loop=None):
-        self.loop = loop or asyncio.get_event_loop()
-        self._function_cache = {}
-        super(AioTestCase, self).__init__(methodName=methodName)
-
-    def coroutine_function_decorator(self, func):
-        def wrapper(*args, **kw):
-            return self.loop.run_until_complete(func(*args, **kw))
-        return wrapper
-
-    def __getattribute__(self, item):
-        attr = object.__getattribute__(self, item)
-        if asyncio.iscoroutinefunction(attr) and item.startswith('test_'):
-            if item not in self._function_cache:
-                self._function_cache[item] = (
-                    self.coroutine_function_decorator(attr))
-            return self._function_cache[item]
-        return attr
-
-
-class TestParallelSeriesUpgrade(AioTestCase):
+class TestParallelSeriesUpgrade(ut_utils.AioTestCase):
     def setUp(self):
         super(TestParallelSeriesUpgrade, self).setUp()
         if sys.version_info < (3, 6, 0):

--- a/zaza/openstack/charm_tests/keystone/setup.py
+++ b/zaza/openstack/charm_tests/keystone/setup.py
@@ -43,7 +43,6 @@ def wait_for_cacert(model_name=None):
     logging.info("Waiting for cacert")
     zaza.openstack.utilities.openstack.block_until_ca_exists(
         'keystone',
-        cert_file,
         'CERTIFICATE',
         model_name=model_name)
     zaza.model.block_until_all_units_idle(model_name=model_name)

--- a/zaza/openstack/charm_tests/keystone/setup.py
+++ b/zaza/openstack/charm_tests/keystone/setup.py
@@ -41,9 +41,7 @@ def wait_for_cacert(model_name=None):
     :type model_name: str
     """
     logging.info("Waiting for cacert")
-    cert_file = openstack_utils.get_cert_file_name(
-        'keystone')
-    zaza.model.block_until_file_has_contents(
+    zaza.openstack.utilities.openstack.block_until_ca_exists(
         'keystone',
         cert_file,
         'CERTIFICATE',

--- a/zaza/openstack/charm_tests/keystone/setup.py
+++ b/zaza/openstack/charm_tests/keystone/setup.py
@@ -41,9 +41,11 @@ def wait_for_cacert(model_name=None):
     :type model_name: str
     """
     logging.info("Waiting for cacert")
+    cert_file = openstack_utils.get_cert_file_name(
+        'keystone')
     zaza.model.block_until_file_has_contents(
         'keystone',
-        openstack_utils.KEYSTONE_REMOTE_CACERT,
+        cert_file,
         'CERTIFICATE',
         model_name=model_name)
     zaza.model.block_until_all_units_idle(model_name=model_name)

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -229,7 +229,7 @@ class AuthenticationAuthorizationTest(BaseKeystoneTest):
                     'OS_DOMAIN_NAME': DEMO_DOMAIN,
                 }
                 if self.tls_rid:
-                    openrc['OS_CACERT'] = openstack_utils.KEYSTONE_LOCAL_CACERT
+                    openrc['OS_CACERT'] = openstack_utils.get_cacert()
                     openrc['OS_AUTH_URL'] = (
                         openrc['OS_AUTH_URL'].replace('http', 'https'))
                 logging.info('keystone IP {}'.format(ip))
@@ -259,7 +259,7 @@ class AuthenticationAuthorizationTest(BaseKeystoneTest):
         """
         def _validate_token_data(openrc):
             if self.tls_rid:
-                openrc['OS_CACERT'] = openstack_utils.KEYSTONE_LOCAL_CACERT
+                openrc['OS_CACERT'] = openstack_utils.get_cacert()
                 openrc['OS_AUTH_URL'] = (
                     openrc['OS_AUTH_URL'].replace('http', 'https'))
             logging.info('keystone IP {}'.format(ip))

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -337,8 +337,7 @@ class BasePolicydSpecialization(PolicydTest,
         logging.info('Authentication for {} on keystone IP {}'
                      .format(openrc['OS_USERNAME'], ip))
         if self.tls_rid:
-            openrc['OS_CACERT'] = \
-                openstack_utils.KEYSTONE_LOCAL_CACERT
+            openrc['OS_CACERT'] = openstack_utils.get_cacert()
             openrc['OS_AUTH_URL'] = (
                 openrc['OS_AUTH_URL'].replace('http', 'https'))
         logging.info('keystone IP {}'.format(ip))

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -222,9 +222,7 @@ def validate_ca(cacertificate, application="keystone", port=5000):
     :returns: None
     :rtype: None
     """
-    cert_file = zaza.openstack.utilities.openstack.get_cert_file_name(
-        application)
-    zaza.model.block_until_file_has_contents(
+    zaza.openstack.utilities.openstack.block_until_ca_exists(
         application,
         cert_file,
         cacertificate.decode().strip())
@@ -238,3 +236,6 @@ def validate_ca(cacertificate, application="keystone", port=5000):
         fp.write(cacertificate.decode())
         fp.flush()
         requests.get('https://{}:{}'.format(ip, str(port)), verify=fp.name)
+
+def get_cert():
+    print(zaza.openstack.utilities.openstack.get_remote_ca_cert_file('masakari'))

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -235,6 +235,3 @@ def validate_ca(cacertificate, application="keystone", port=5000):
         fp.write(cacertificate.decode())
         fp.flush()
         requests.get('https://{}:{}'.format(ip, str(port)), verify=fp.name)
-
-def get_cert():
-    print(zaza.openstack.utilities.openstack.get_remote_ca_cert_file('masakari'))

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -222,9 +222,11 @@ def validate_ca(cacertificate, application="keystone", port=5000):
     :returns: None
     :rtype: None
     """
+    cert_file = zaza.openstack.utilities.openstack.get_cert_file_name(
+        application)
     zaza.model.block_until_file_has_contents(
         application,
-        zaza.openstack.utilities.openstack.KEYSTONE_REMOTE_CACERT,
+        cert_file,
         cacertificate.decode().strip())
     vip = (zaza.model.get_application_config(application)
            .get("vip").get("value"))

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -224,7 +224,6 @@ def validate_ca(cacertificate, application="keystone", port=5000):
     """
     zaza.openstack.utilities.openstack.block_until_ca_exists(
         application,
-        cert_file,
         cacertificate.decode().strip())
     vip = (zaza.model.get_application_config(application)
            .get("vip").get("value"))

--- a/zaza/openstack/charm_tests/vault/tests.py
+++ b/zaza/openstack/charm_tests/vault/tests.py
@@ -154,9 +154,7 @@ class VaultTest(BaseVaultTest):
 
         test_config = lifecycle_utils.get_charm_config()
         del test_config['target_deploy_status']['vault']
-        cert_file = zaza.openstack.utilities.openstack.get_cert_file_name(
-            'keystone')
-        zaza.model.block_until_file_has_contents(
+        zaza.openstack.utilities.openstack.block_until_ca_exists(
             'keystone',
             cert_file,
             cacert.decode().strip())

--- a/zaza/openstack/charm_tests/vault/tests.py
+++ b/zaza/openstack/charm_tests/vault/tests.py
@@ -154,9 +154,11 @@ class VaultTest(BaseVaultTest):
 
         test_config = lifecycle_utils.get_charm_config()
         del test_config['target_deploy_status']['vault']
+        cert_file = zaza.openstack.utilities.openstack.get_cert_file_name(
+            'keystone')
         zaza.model.block_until_file_has_contents(
             'keystone',
-            zaza.openstack.utilities.openstack.KEYSTONE_REMOTE_CACERT,
+            cert_file,
             cacert.decode().strip())
         zaza.model.wait_for_application_states(
             states=test_config.get('target_deploy_status', {}))

--- a/zaza/openstack/charm_tests/vault/tests.py
+++ b/zaza/openstack/charm_tests/vault/tests.py
@@ -156,7 +156,6 @@ class VaultTest(BaseVaultTest):
         del test_config['target_deploy_status']['vault']
         zaza.openstack.utilities.openstack.block_until_ca_exists(
             'keystone',
-            cert_file,
             cacert.decode().strip())
         zaza.model.wait_for_application_states(
             states=test_config.get('target_deploy_status', {}))

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2053,7 +2053,7 @@ def get_overcloud_auth(address=None, model_name=None):
             'API_VERSION': 3,
         }
     local_ca_cert = get_remote_ca_cert_file('keystone', model_name=model_name)
-    if ca_cert:
+    if local_ca_cert:
         auth_settings['OS_CACERT'] = local_ca_cert
 
     return auth_settings

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -222,6 +222,7 @@ async def async_block_until_ca_exists(application_name, ca_cert,
                 except JujuError:
                     continue
             else:
+                # The CA was found in `ca_file` on all units.
                 return True
         else:
             return False
@@ -2012,6 +2013,15 @@ def get_overcloud_auth(address=None, model_name=None):
 
 async def _async_get_remote_ca_cert_file_candidates(application,
                                                     model_name=None):
+    """Return a list of possible remote CA file names.
+
+    :param application: Name of application to examine.
+    :type application: str
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :returns: List of paths to possible ca files.
+    :rtype: List[str]
+    """
     cert_files = []
     for _provider in CERT_PROVIDERS:
         tls_rid = await model.async_get_relation_id(
@@ -2023,7 +2033,7 @@ async def _async_get_remote_ca_cert_file_candidates(application,
             cert_files.append(
                 REMOTE_CERT_DIR + '/' + CACERT_FILENAME_FORMAT.format(
                     _provider))
-    cert_files.append(KEYSTONE_LOCAL_CACERT)
+    cert_files.append(KEYSTONE_REMOTE_CACERT)
     return cert_files
 
 _get_remote_ca_cert_file_candidates = zaza.model.sync_wrapper(

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -184,7 +184,7 @@ WORKLOAD_STATUS_EXCEPTIONS = {
 
 # For vault TLS certificates
 CACERT_FILENAME_FORMAT = "{}_juju_ca_cert.crt"
-CERT_PROVIDORS = ['vault']
+CERT_PROVIDERS = ['vault']
 LOCAL_CERT_DIR = "tests"
 REMOTE_CERT_DIR = "/usr/local/share/ca-certificates"
 KEYSTONE_CACERT = "keystone_juju_ca_cert.crt"
@@ -192,33 +192,29 @@ KEYSTONE_REMOTE_CACERT = (
     "/usr/local/share/ca-certificates/{}".format(KEYSTONE_CACERT))
 KEYSTONE_LOCAL_CACERT = ("{}/{}".format(LOCAL_CERT_DIR, KEYSTONE_CACERT))
 
-VAULT_CACERT = "vault_juju_ca_cert.crt"
-VAULT_REMOTE_CACERT = (
-    "/usr/local/share/ca-certificates/{}".format(VAULT_CACERT))
-VAULT_LOCAL_CACERT = ("{}/{}".format(LOCAL_CERT_DIR, VAULT_CACERT))
 
-REMOTE_CERTIFICATES = [VAULT_REMOTE_CACERT, KEYSTONE_REMOTE_CACERT]
-LOCAL_CERTIFICATES = [VAULT_LOCAL_CACERT, KEYSTONE_LOCAL_CACERT]
+async def async_block_until_ca_exists(application_name, ca_cert,
+                                      model_name=None, timeout=2700):
+    """Block until a CA cert is on all units of application_name.
 
-
-async def async_block_until_ca_exists(application_name, ca_cert, model_name=None, timeout=2700):
+    :param application_name: Name of application to check
+    :type application_name: str
+    :param ca_cert: The certificate to look for.
+    :type ca_cert: str
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :param timeout: How long in seconds to wait
+    :type timeout: int
+    """
     async def _check_ca_present(model, ca_files):
         units = model.applications[application_name].units
-        print(ca_files)
         for ca_file in ca_files:
             for unit in units:
-                print(unit)
-                print(ca_file)
                 try:
                     output = await unit.run('cat {}'.format(ca_file))
                     contents = output.data.get('results').get('Stdout', '')
-                    if not ca_cert in contents:
-                        print("It's not here!")
-                        print(ca_cert)
-                        print(contents)
+                    if ca_cert not in contents:
                         break
-                    if ca_cert in contents:
-                        print("It's here!")
                 # libjuju throws a generic error for connection failure. So we
                 # cannot differentiate between a connectivity issue and a
                 # target file not existing error. For now just assume the
@@ -229,8 +225,9 @@ async def async_block_until_ca_exists(application_name, ca_cert, model_name=None
                 return True
         else:
             return False
-    ca_files = await _async_get_remote_ca_cert_file_candidates(application_name, model_name=model_name)
-    print(ca_files)
+    ca_files = await _async_get_remote_ca_cert_file_candidates(
+        application_name,
+        model_name=model_name)
     async with zaza.model.run_in_model(model_name) as model:
         await zaza.model.async_block_until(
             lambda: _check_ca_present(model, ca_files), timeout=timeout)
@@ -238,65 +235,19 @@ async def async_block_until_ca_exists(application_name, ca_cert, model_name=None
 block_until_ca_exists = zaza.model.sync_wrapper(async_block_until_ca_exists)
 
 
-
-#async def async_get_cert_file_name(app, cert_files=None, block=True,
-#                                   model_name=None, timeout=2700):
-#    """Get the name of the CA cert file thats on all units of an application.
-#
-#    :param app: Name of application
-#    :type capp: str
-#    :param cert_files: List of cert files to search for.
-#    :type cert_files: List[str]
-#    :param block: Whether to block until a consistent cert file is found.
-#    :type block: bool
-#    :param model_name: Name of model to run check in
-#    :type model_name: str
-#    :param timeout: Time to wait for consistent file
-#    :type timeout: int
-#    :returns: Credentials dictionary
-#    :rtype: dict
-#    """
-#    async def _check_for_file(model, cert_files):
-#        units = model.applications[app].units
-#        results = {u.entity_id: [] for u in units}
-#        for unit in units:
-#            try:
-#                for cf in cert_files:
-#                    output = await unit.run('test -e "{}"; echo $?'.format(cf))
-#                    contents = output.data.get('results')['Stdout']
-#                    if "0" in contents:
-#                        results[unit.entity_id].append(cf)
-#            except JujuError:
-#                pass
-#        for cert_file in cert_files:
-#            # Check that the certificate file exists on all the units.
-#            if all(cert_file in files for files in results.values()):
-#                return cert_file
-#        else:
-#            return None
-#
-#    if not cert_files:
-#        cert_files = REMOTE_CERTIFICATES
-#    cert_file = None
-#    async with zaza.model.run_in_model(model_name) as model:
-#        if block:
-#            await zaza.model.async_block_until(
-#                lambda: _check_for_file(model, cert_files), timeout=timeout)
-#        cert_file = await _check_for_file(model, cert_files)
-#    return cert_file
-#
-#get_cert_file_name = zaza.model.sync_wrapper(async_get_cert_file_name)
-
-
 def get_cacert():
     """Return path to CA Certificate bundle for verification during test.
 
     :returns: Path to CA Certificate bundle or None.
-    :rtype: Optional[str]
+    :rtype: Union[str, None]
     """
-    for _cert in LOCAL_CERTIFICATES:
+    for _provider in CERT_PROVIDERS:
+        _cert = LOCAL_CERT_DIR + '/' + CACERT_FILENAME_FORMAT.format(
+            _provider)
         if os.path.exists(_cert):
             return _cert
+    if os.path.exists(KEYSTONE_LOCAL_CACERT):
+        return KEYSTONE_LOCAL_CACERT
 
 
 # OpenStack Client helpers
@@ -2058,64 +2009,67 @@ def get_overcloud_auth(address=None, model_name=None):
 
     return auth_settings
 
-async def _async_get_remote_ca_cert_file_candidates(application, model_name=None):
+
+async def _async_get_remote_ca_cert_file_candidates(application,
+                                                    model_name=None):
     cert_files = []
-    # unit = model.get_first_unit_name(application, model_name=model_name)
-    units = await model.async_get_units(application, model_name=model_name)
-    unit = units[0].name
-    for _providor in CERT_PROVIDORS:
+    for _provider in CERT_PROVIDERS:
         tls_rid = await model.async_get_relation_id(
             application,
-            _providor,
+            _provider,
             model_name=model_name,
             remote_interface_name='certificates')
         if tls_rid:
-            cert_files.append(REMOTE_CERT_DIR + '/' + CACERT_FILENAME_FORMAT.format(_providor))
-    cert_files.append(REMOTE_CERT_DIR + '/' + KEYSTONE_CACERT)
+            cert_files.append(
+                REMOTE_CERT_DIR + '/' + CACERT_FILENAME_FORMAT.format(
+                    _provider))
+    cert_files.append(KEYSTONE_LOCAL_CACERT)
     return cert_files
 
-_get_remote_ca_cert_file_candidates = zaza.model.sync_wrapper(_async_get_remote_ca_cert_file_candidates)
+_get_remote_ca_cert_file_candidates = zaza.model.sync_wrapper(
+    _async_get_remote_ca_cert_file_candidates)
+
 
 def get_remote_ca_cert_file(application, model_name=None):
-#    CACERT_FILENAME = "{}_juju_ca_cert.crt"
-#    cert_files = []
-#    unit = model.get_first_unit_name(application, model_name=model_name)
-#    for _providor in CERT_PROVIDORS:
-#        tls_rid = model.get_relation_id(
-#            application,
-#            _providor,
-#            model_name=model_name,
-#            remote_interface_name='certificates')
-#        if tls_rid:
-#            cert_files.append(CACERT_FILENAME.format(_providor))
-#    cert_files.append(KEYSTONE_CACERT)
+    """Collect CA certificate from application.
+
+    :param application: Name of application to collect file from.
+    :type application: str
+    :param model_name: Name of model to query.
+    :type model_name: str
+    :returns: Path to cafile
+    :rtype: str
+    """
     unit = model.get_first_unit_name(application, model_name=model_name)
     local_cert_file = None
-    cert_files = _get_remote_ca_cert_file_candidates(application, model_name=model_name)
+    cert_files = _get_remote_ca_cert_file_candidates(
+        application,
+        model_name=model_name)
     for cert_file in cert_files:
         _local_cert_file = "{}/{}".format(
             LOCAL_CERT_DIR,
             os.path.basename(cert_file))
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as _tmp_ca_file:
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as _tmp_ca:
             try:
                 model.scp_from_unit(
                     unit,
                     cert_file,
-                    _tmp_ca_file.name)
+                    _tmp_ca.name)
             except JujuError:
                 continue
-            # ensure that the path to put the local cacert in actually exists.  The
-            # assumption that 'tests/' exists for, say, mojo is false.
+            # ensure that the path to put the local cacert in actually exists.
+            # The assumption that 'tests/' exists for, say, mojo is false.
             # Needed due to:
             # commit: 537473ad3addeaa3d1e4e2d0fd556aeaa4018eb2
             _dir = os.path.dirname(_local_cert_file)
             if not os.path.exists(_dir):
                 os.makedirs(_dir)
-            shutil.move(_tmp_ca_file.name, _local_cert_file)
+            shutil.move(_tmp_ca.name, _local_cert_file)
             os.chmod(_local_cert_file, 0o644)
             local_cert_file = _local_cert_file
             break
     return local_cert_file
+
 
 def get_urllib_opener():
     """Create a urllib opener taking into account proxy settings.

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -199,7 +199,7 @@ async def async_block_until_ca_exists(application_name, ca_cert,
 
     :param application_name: Name of application to check
     :type application_name: str
-    :param ca_cert: The certificate to look for.
+    :param ca_cert: The certificate content.
     :type ca_cert: str
     :param model_name: Name of model to query.
     :type model_name: str
@@ -220,7 +220,7 @@ async def async_block_until_ca_exists(application_name, ca_cert,
                 # target file not existing error. For now just assume the
                 # latter.
                 except JujuError:
-                    continue
+                    break
             else:
                 # The CA was found in `ca_file` on all units.
                 return True


### PR DESCRIPTION
Update code to stop assuming that a charms CA file is called keystone_juju_ca_cert.crt. 

Closes issue #487