### PR TITLE
Skip OVN provider octavia test on Victoria

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -178,6 +178,14 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
             for provider in octavia_client.provider_list().get('providers', [])
             if provider['name'] != 'octavia'  # alias for `amphora`, skip
         }
+        if (openstack_utils.get_os_release() in [
+                openstack_utils.get_os_release('focal_victoria'),
+                openstack_utils.get_os_release('groovy_victoria')]):
+            logging.info("Skipping tests of ovn backed lb (Bug #1896603)")
+            try:
+                del providers['ovn']
+            except KeyError:
+                pass
         return providers
 
     def _create_lb_resources(self, octavia_client, provider, vip_subnet_id,


### PR DESCRIPTION
The OVN provider octavia test on Victoria is currently broken due
to Bug #1896603. Until it is fixed skip the test.