### PR TITLE
Replace get_relation_from_unit for designate test

### DIFF
--- a/zaza/openstack/charm_tests/designate/tests.py
+++ b/zaza/openstack/charm_tests/designate/tests.py
@@ -23,7 +23,7 @@ import designateclient.v1.records as records
 import designateclient.v1.servers as servers
 
 import zaza.model
-import zaza.openstack.utilities.juju as zaza_juju
+import zaza.utilities.juju as juju_utils
 import zaza.openstack.charm_tests.test_utils as test_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 import zaza.openstack.charm_tests.designate.utils as designate_utils
@@ -170,7 +170,7 @@ class DesignateAPITests(BaseDesignateTest):
         reraise=True
     )
     def _wait_to_resolve_test_record(self):
-        dns_ip = zaza_juju.get_relation_from_unit(
+        dns_ip = juju_utils.get_relation_from_unit(
             'designate/0',
             'designate-bind/0',
             'dns-backend'


### PR DESCRIPTION
In the current state, deprecation warnings will show for the `get_relation_from_unit` method when running tox:

```
[WARNING] get_relation_from_unit from zaza.openstack.utilities.juju is deprecated. Please use the equivalent from zaza.utilities.juju
```

This will remove the error. There are other files using this method as well, but to keep the change atomic, they will be handled separately. I changed the library alias to be `juju_utils` to be consistent with [other cases that already exist in the repo](https://github.com/openstack-charmers/zaza-openstack-tests/blob/91924c5caf40ac59039ea52fb13ab83325ac469f/zaza/openstack/utilities/openstack.py#L2934).