### PR TITLE
Replace get_relation_from_unit for ceph test

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -33,7 +33,7 @@ import zaza.model as zaza_model
 import zaza.openstack.utilities.ceph as zaza_ceph
 import zaza.openstack.utilities.exceptions as zaza_exceptions
 import zaza.openstack.utilities.generic as zaza_utils
-import zaza.openstack.utilities.juju as zaza_juju
+import zaza.utilities.juju as juju_utils
 import zaza.openstack.utilities.openstack as zaza_openstack
 
 
@@ -124,7 +124,7 @@ class CephRelationTest(test_utils.OpenStackBaseTest):
         relation_name = 'osd'
         remote_unit = zaza_model.get_unit_from_name(remote_unit_name)
         remote_ip = remote_unit.public_address
-        relation = zaza_juju.get_relation_from_unit(
+        relation = juju_utils.get_relation_from_unit(
             unit_name,
             remote_unit_name,
             relation_name
@@ -153,7 +153,7 @@ class CephRelationTest(test_utils.OpenStackBaseTest):
             'ceph-public-address': remote_ip,
             'fsid': fsid,
         }
-        relation = zaza_juju.get_relation_from_unit(
+        relation = juju_utils.get_relation_from_unit(
             unit_name,
             remote_unit_name,
             relation_name
@@ -980,7 +980,7 @@ class BlueStoreCompressionCharmOperation(test_utils.BaseCharmTest):
         ceph_pools_detail = zaza_ceph.get_ceph_pool_details(
             model_name=self.model_name)
         logging.debug('AFTER: {}'.format(ceph_pools_detail))
-        logging.debug(zaza_juju.get_relation_from_unit(
+        logging.debug(juju_utils.get_relation_from_unit(
             'ceph-mon', self.application_name, None,
             model_name=self.model_name))
         logging.info('Checking Ceph pool compression_mode after restoring '


### PR DESCRIPTION
In the current state, deprecation warnings will show for the `get_relation_from_unit` method when running tox:

```
[WARNING] get_relation_from_unit from zaza.openstack.utilities.juju is deprecated. Please use the equivalent from zaza.utilities.juju
```

This will remove the error. There are other files using this method as well, but to keep the change atomic, they will be handled separately. I changed the library alias to be `juju_utils` to be consistent with [other cases that already exist in the repo](https://github.com/openstack-charmers/zaza-openstack-tests/blob/91924c5caf40ac59039ea52fb13ab83325ac469f/zaza/openstack/utilities/openstack.py#L2934).