### PR TITLE
Zaza_juju rename

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_ceph.py
+++ b/unit_tests/utilities/test_zaza_utilities_ceph.py
@@ -118,7 +118,7 @@ class TestCephUtils(ut_utils.BaseTestCase):
                                     model_name='amodel')
 
     def test_pools_from_broker_req(self):
-        self.patch_object(ceph_utils.zaza_juju, 'get_relation_from_unit')
+        self.patch_object(ceph_utils.juju_utils, 'get_relation_from_unit')
         self.get_relation_from_unit.return_value = {
             'broker_req': (
                 '{"api-version": 1, "ops": ['

--- a/zaza/openstack/utilities/ceph.py
+++ b/zaza/openstack/utilities/ceph.py
@@ -3,7 +3,7 @@ import json
 import logging
 
 import zaza.model as zaza_model
-import zaza.utilities.juju as zaza_juju
+import zaza.utilities.juju as juju_utils
 
 import zaza.openstack.utilities.openstack as openstack_utils
 
@@ -225,7 +225,7 @@ def get_pools_from_broker_req(application_or_unit, model_name=None):
     """
     # NOTE: we do not pass on a name for the remote_interface_name as that
     # varies between the Ceph consuming applications.
-    relation_data = zaza_juju.get_relation_from_unit(
+    relation_data = juju_utils.get_relation_from_unit(
         'ceph-mon', application_or_unit, None, model_name=model_name)
 
     # NOTE: we probably should consume the Ceph broker code from c-h but c-h is


### PR DESCRIPTION
Renaming `zaza_juju` in a few import statements to be consistent with the `juju_utils` name across the rest of the repository.