### PR TITLE
Fix race condition in MySQL tests

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -589,6 +589,10 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
                 unit.entity_id,
                 'blocked')
 
+        # Wait until update-status hooks have completed
+        logging.info("Wait till model is idle ...")
+        zaza.model.block_until_all_units_idle()
+
         logging.info("Execute reboot-cluster-from-complete-outage "
                      "action after cold boot ...")
         # We do not know which unit has the most up to date data

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -771,6 +771,9 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
         zaza.model.block_until_wl_status_info_starts_with(
             self.application, "'cluster' incomplete")
 
+        # Show status
+        logging.info(self.get_cluster_status())
+
         logging.info(
             "Removing old unit from cluster: {} "
             .format(leader_unit.public_address))
@@ -842,6 +845,9 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
 
         logging.info("Wait for status ready ...")
         zaza.model.wait_for_application_states(states=self.states)
+
+        # Show status
+        logging.info(self.get_cluster_status())
 
         logging.info(
             "Removing old unit from cluster: {} "


### PR DESCRIPTION
In the MySQL test we destroy a unit and then attempt to remove it from
metadata. The metadata removal (remove_instance action) gets stuck when it is
started while the destroyed unit has not been entirely removed and is still
running MySQL.

Wait for all the units to have cluster incomplete workload status message
before attempting the remove_instance.