### PR TITLE
Add keystoneauth1 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ python-cinderclient
 python-glanceclient
 python-heatclient
 python-ironicclient
+keystoneauth1
 python-keystoneclient
 python-manilaclient
 python-neutronclient


### PR DESCRIPTION
keystoneauth1 is a dependency since commit 4cccbdc9 and there are certain
environments where it's doesn't get installed indirectly.

Traceback (most recent call last):
  File ".tox/func/bin/functest-run-suite", line 8, in <module>
    sys.exit(main())
  ...
  File ".tox/func/lib/python3.8/site-packages/zaza/utilities/openstack_provider.py", line 21, in <module>
    from keystoneauth1 import session
ModuleNotFoundError: No module named 'keystoneauth1'