### PR TITLE
Pin cryptography < 3.4 due to rust compiler requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography<3.4
 aiounittest
 async_generator
 boto3
@@ -44,8 +45,3 @@ paramiko
 sphinx
 sphinxcontrib-asyncio
 git+https://github.com/openstack-charmers/zaza#egg=zaza
-
-# Newer versions require a Rust compiler to build, see
-# * https://github.com/openstack-charmers/zaza/issues/421
-# * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
-cryptography<3.4


### PR DESCRIPTION
We need to pin the module due to requiring a rust compiler to build it
(or setting an ENV var).  At the moment we are pinning, but we will need
to review this once we've worked out what to do about the rust
requirements.