### PR TITLE
Fix the kerberos set-up by loosening ubuntu check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,26 @@ commands = nosetests --with-coverage --cover-package=zaza.openstack {posargs} {t
 basepython = python3
 deps = -r{toxinidir}/requirements.txt
 
+[testenv:py3.5]
+basepython = python3.5
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:py3.6]
+basepython = python3.6
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:py3.7]
+basepython = python3.7
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:py3.8]
+basepython = python3.8
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:py3.9]
+basepython = python3.9
+deps = -r{toxinidir}/requirements.txt
+
 [testenv:pep8]
 basepython = python3
 deps = -r{toxinidir}/requirements.txt

--- a/zaza/openstack/charm_tests/kerberos/setup.py
+++ b/zaza/openstack/charm_tests/kerberos/setup.py
@@ -113,7 +113,15 @@ def retrieve_and_attach_keytab():
                                    'keystone_keytab',
                                    tmp_file)
 
-    zaza.model.wait_for_application_states()
+    # cs:ubuntu charm has changed behaviour and we can't rely on the workload
+    # staus message.  Thus, ignore it.
+    states = {
+        "ubuntu-test-host": {
+            "workload-status": "active",
+            "workload-status-message": "",
+        }
+    }
+    zaza.model.wait_for_application_states(states=states)
     zaza.model.block_until_all_units_idle()
 
 


### PR DESCRIPTION
The cs:ubuntu charm's workload-status-message has changed recently (as
the charm was re-written).  This PR loosens the application states check
to ignore the workload-status-message and just wait for the charm to be
active workload-status.  This is almost certainly enough, as it's a very
simple charm.