### PR TITLE
Add Manila NetApp tests

### DIFF
--- a/zaza/openstack/charm_tests/manila_netapp/__init__.py
+++ b/zaza/openstack/charm_tests/manila_netapp/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate Manila NetApp setup and testing."""

--- a/zaza/openstack/charm_tests/manila_netapp/setup.py
+++ b/zaza/openstack/charm_tests/manila_netapp/setup.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate Manila NetApp setup."""
+
+import zaza.openstack.utilities.openstack as openstack_utils
+import zaza.openstack.charm_tests.neutron.setup as neutron_setup
+
+
+MANILA_NETAPP_TYPE_NAME = "netapp-ontap"
+MANILA_NETAPP_BACKEND_NAME = "netapp-ontap"
+
+MANILA_NETAPP_DHSS_TYPE_NAME = "netapp-ontap-dhss"
+MANILA_NETAPP_DHSS_BACKEND_NAME = "netapp-ontap-dhss"
+
+MANILA_NETAPP_SHARE_NET_NAME = "netapp-ontap-share-network"
+
+
+def create_netapp_share_type(manila_client=None):
+    """Create a share type for Manila with NetApp Data ONTAP driver.
+
+    :param manila_client: Authenticated manilaclient
+    :type manila_client: manilaclient.Client
+    """
+    if manila_client is None:
+        manila_client = openstack_utils.get_manila_session_client(
+            openstack_utils.get_overcloud_keystone_session())
+
+    manila_client.share_types.create(
+        name=MANILA_NETAPP_TYPE_NAME,
+        spec_driver_handles_share_servers=False,
+        extra_specs={
+            'vendor_name': 'NetApp',
+            'share_backend_name': MANILA_NETAPP_BACKEND_NAME,
+            'storage_protocol': 'NFS_CIFS',
+        })
+
+
+def create_netapp_dhss_share_type(manila_client=None):
+    """Create a DHSS share type for Manila with NetApp Data ONTAP driver.
+
+    :param manila_client: Authenticated manilaclient
+    :type manila_client: manilaclient.Client
+    """
+    if manila_client is None:
+        manila_client = openstack_utils.get_manila_session_client(
+            openstack_utils.get_overcloud_keystone_session())
+
+    manila_client.share_types.create(
+        name=MANILA_NETAPP_DHSS_TYPE_NAME,
+        spec_driver_handles_share_servers=True,
+        extra_specs={
+            'vendor_name': 'NetApp',
+            'share_backend_name': MANILA_NETAPP_DHSS_BACKEND_NAME,
+            'storage_protocol': 'NFS_CIFS',
+        })
+
+
+def create_netapp_share_network(manila_client=None):
+    """Create a Manila share network from the existing provider network.
+
+    This setup function assumes that 'neutron.setup.basic_overcloud_network'
+    is called to have the proper tenant networks setup.
+
+    The share network will be bound to the provider network configured by
+    'neutron.setup.basic_overcloud_network'.
+    """
+    session = openstack_utils.get_overcloud_keystone_session()
+    if manila_client is None:
+        manila_client = openstack_utils.get_manila_session_client(session)
+
+    neutron = openstack_utils.get_neutron_session_client(session)
+    external_net = neutron.find_resource(
+        'network',
+        neutron_setup.OVERCLOUD_NETWORK_CONFIG['external_net_name'])
+    external_subnet = neutron.find_resource(
+        'subnet',
+        neutron_setup.OVERCLOUD_NETWORK_CONFIG['external_subnet_name'])
+
+    manila_client.share_networks.create(
+        name=MANILA_NETAPP_SHARE_NET_NAME,
+        neutron_net_id=external_net['id'],
+        neutron_subnet_id=external_subnet['id'])

--- a/zaza/openstack/charm_tests/manila_netapp/tests.py
+++ b/zaza/openstack/charm_tests/manila_netapp/tests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Encapsulate Manila NetApp testing."""
+
+from zaza.openstack.charm_tests.manila_netapp.setup import (
+    MANILA_NETAPP_TYPE_NAME,
+    MANILA_NETAPP_DHSS_TYPE_NAME,
+    MANILA_NETAPP_SHARE_NET_NAME,
+)
+
+import zaza.openstack.charm_tests.manila.tests as manila_tests
+
+
+class ManilaNetAppNFSTest(manila_tests.ManilaBaseTest):
+    """Encapsulate Manila NetApp NFS test."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running tests."""
+        super(ManilaNetAppNFSTest, cls).setUpClass()
+        cls.share_name = 'netapp-ontap-share'
+        cls.share_type_name = MANILA_NETAPP_TYPE_NAME
+        cls.share_protocol = 'nfs'
+
+
+class ManilaNetAppDHSSNFSTest(manila_tests.ManilaBaseTest):
+    """Encapsulate Manila NetApp NFS test."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running tests."""
+        super(ManilaNetAppDHSSNFSTest, cls).setUpClass()
+        cls.share_name = 'netapp-ontap-dhss-share'
+        cls.share_type_name = MANILA_NETAPP_DHSS_TYPE_NAME
+        cls.share_protocol = 'nfs'
+        cls.share_network = cls.manila_client.share_networks.find(
+            name=MANILA_NETAPP_SHARE_NET_NAME)

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -69,6 +69,7 @@ from neutronclient.v2_0 import client as neutronclient
 from neutronclient.common import exceptions as neutronexceptions
 from octaviaclient.api.v2 import octavia as octaviaclient
 from swiftclient import client as swiftclient
+from manilaclient import client as manilaclient
 
 from juju.errors import JujuError
 
@@ -447,6 +448,19 @@ def get_aodh_session_client(session):
     :rtype: openstack.instance_ha.v1._proxy.Proxy
     """
     return aodh_client.Client(session=session)
+
+
+def get_manila_session_client(session, version='2'):
+    """Return Manila client authenticated by keystone session.
+
+    :param session: Keystone session object
+    :type session: keystoneauth1.session.Session object
+    :param version: Manila API version
+    :type version: str
+    :returns: Authenticated manilaclient
+    :rtype: manilaclient.Client
+    """
+    return manilaclient.Client(session=session, client_version=version)
 
 
 def get_keystone_scope(model_name=None):


### PR DESCRIPTION
These Zaza tests are meant to be used with the new `manila-netapp` charm.