### PR TITLE
Add upgrades doc note

### DIFF
--- a/zaza/openstack/utilities/upgrade_utils.py
+++ b/zaza/openstack/utilities/upgrade_utils.py
@@ -26,7 +26,13 @@ from zaza.openstack.utilities.os_versions import (
     OPENSTACK_RELEASES_PAIRS,
 )
 
-
+"""
+The below upgrade order is surfaced in end-user documentation. Any change to it
+should be accompanied by an update to the OpenStack Charms Deployment Guide for
+both charm upgrades and payload upgrades:
+- source/upgrade-charms.rst#upgrade-order
+- source/upgrade-openstack.rst#openstack_upgrade_order
+"""
 SERVICE_GROUPS = (
     ('Database Services', ['percona-cluster', 'mysql-innodb-cluster']),
     ('Stateful Services', ['rabbitmq-server', 'ceph-mon']),


### PR DESCRIPTION
Add a note so that upgrade testing (charms and payload) remains in sync with the end-user documentation (CDG).