### PR TITLE
Pin lxml to 4.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# pin lxml < 4.6.3 for py35 as no wheels exist for 4.6.3 (deprecated platform)
+# This is necessary for Xenial builders
+# BUG: https://github.com/openstack-charmers/zaza-openstack-tests/issues/530
+lxml<4.6.3
 aiounittest
 async_generator
 boto3


### PR DESCRIPTION
See https://github.com/openstack-charmers/zaza-openstack-tests/issues/530

Issue:

    Python 3.5. is deprecated/EOL
    Py35 is used on Xenial
    Xenial is used as the test platform to run tests.
    lxml is used by zaza-openstack-tests for the SAML assertions (because they are XML)
    lxml > 4.6.2 releases are after py3.5 has been deprecated/EOL.
    Therefore, no wheels are now built for lxml for py35.
    Thus there is a binary dependency to build lxml for testing