### PR TITLE
Fix Ceph service action tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/osd/tests.py
+++ b/zaza/openstack/charm_tests/ceph/osd/tests.py
@@ -258,8 +258,11 @@ class ServiceTest(unittest.TestCase):
         to_start = should_stop.pop()
         should_stop = [service.name for service in should_stop]
 
+        # Note: can't stop ceph-osd.target as restarting a single OSD will
+        # cause this to start all of the OSDs when a single one starts.
         logging.info("Stopping all running ceph-osd services")
-        service_stop_cmd = 'systemctl stop ceph-osd.target'
+        service_stop_cmd = '; '.join(['systemctl stop {}'.format(service)
+                                      for service in service_names])
         zaza_model.run_on_unit(self.TESTED_UNIT, service_stop_cmd)
 
         wait_for_service(unit_name=self.TESTED_UNIT,


### PR DESCRIPTION
The ServiceTest.test_start_specific under the ceph osd tests stops all
services using ceph-osd.target. This will stop all the OSDs, but the
restarting of any single OSD will restart all the OSDs. This behavior
causes the charm test to fail.

Unfortunately, this wasn't caught in the initial review because the test
is skipped when there are fewer the 2 OSDs on a unit and the final test
run skipped the test due to this condition.

Fixes #542

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>