### PR TITLE
Fix Ceph service action tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/osd/tests.py
+++ b/zaza/openstack/charm_tests/ceph/osd/tests.py
@@ -258,8 +258,11 @@ class ServiceTest(unittest.TestCase):
         to_start = should_stop.pop()
         should_stop = [service.name for service in should_stop]
 
+        # Note: can't stop ceph-osd.target as restarting a single OSD will
+        # cause this to start all of the OSDs when a single one starts.
         logging.info("Stopping all running ceph-osd services")
-        service_stop_cmd = 'systemctl stop ceph-osd.target'
+        service_stop_cmd = '; '.join(['systemctl stop {}'.format(service)
+                                      for service in service_names])
         zaza_model.run_on_unit(self.TESTED_UNIT, service_stop_cmd)
 
         wait_for_service(unit_name=self.TESTED_UNIT,

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -617,10 +617,14 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
         zaza.model.wait_for_application_states(
             states=test_config.get("target_deploy_status", {}))
 
-    def test_110_force_quorum_using_partition_of(self):
+    def disabled_test_110_force_quorum_using_partition_of(self):
         """Force quorum using partition of instance with given address.
 
         After outage, cluster can end up without quorum. Force it.
+
+        NOTE(lourot): temporarily disabling this test in stable/21.04 because
+        the charm feature hasn't landed yet:
+        https://review.opendev.org/c/openstack/charm-mysql-innodb-cluster/+/779427
         """
         logging.info("Wait till model is idle ...")
         zaza.model.block_until_all_units_idle()


### PR DESCRIPTION
Backport of #543 (validated [here](https://review.opendev.org/c/openstack/charm-ceph-osd/+/785555)) to stable/21.04.
Fixes #542 and unblocks the [libraries-sync-21-04 batch](https://review.opendev.org/q/topic:libraries-sync-21-04)