### PR TITLE
Fix Neutron Gateway deferred restart test

### DIFF
--- a/zaza/openstack/charm_tests/neutron/tests.py
+++ b/zaza/openstack/charm_tests/neutron/tests.py
@@ -1045,3 +1045,7 @@ class NeutronGatewayDeferredRestartTest(test_utils.BaseDeferredRestartTest):
         self.run_package_change_test(
             'openvswitch-switch',
             'openvswitch-switch')
+
+    def check_clear_hooks(self):
+        """Gateway does not defer hooks so noop."""
+        return


### PR DESCRIPTION
Do not run the deferred hooks action for neutron gateway as it is
not needed and will end in an action error.

Tested locally here: https://paste.ubuntu.com/p/cSmgxmrTr4/

This closes issue #553