### PR TITLE
MySQL Partition Test class

### DIFF
--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -864,7 +864,7 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
 
 
 class MySQLInnoDBClusterPartitionTest(MySQLBaseTest):
-    """MySQL parition handling."""
+    """MySQL partition handling."""
 
     def test_850_force_quorum_using_partition_of(self):
         """Force quorum using partition of instance with given address.

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -617,73 +617,6 @@ class MySQLInnoDBClusterColdStartTest(MySQLBaseTest):
         zaza.model.wait_for_application_states(
             states=test_config.get("target_deploy_status", {}))
 
-    def test_110_force_quorum_using_partition_of(self):
-        """Force quorum using partition of instance with given address.
-
-        After outage, cluster can end up without quorum. Force it.
-        """
-        logging.info("Wait till model is idle ...")
-        zaza.model.block_until_all_units_idle()
-
-        # Block all traffic across mysql instances: 0<-1, 1<-2 and 2<-0
-        mysql_units = [unit for unit in zaza.model.get_units(self.application)]
-        no_of_units = len(mysql_units)
-        for index, unit in enumerate(mysql_units):
-            next_unit = mysql_units[(index+1) % no_of_units]
-            ip_address = next_unit.public_address
-            cmd = "sudo iptables -A INPUT -s {} -j DROP".format(ip_address)
-            zaza.model.async_run_on_unit(unit, cmd)
-
-        logging.info(
-            "Wait till all {} units are in state 'blocked' ..."
-            .format(self.application))
-        for unit in zaza.model.get_units(self.application):
-            zaza.model.block_until_unit_wl_status(
-                unit.entity_id,
-                'blocked',
-                negate_match=True)
-
-        logging.info("Wait till model is idle ...")
-        zaza.model.block_until_all_units_idle()
-
-        logging.info("Execute force-quorum-using-partition-of action ...")
-
-        # Select "quorum leader" unit
-        leader_unit = mysql_units[0]
-        action = zaza.model.run_action(
-            leader_unit.entity_id,
-            "force-quorum-using-partition-of",
-            action_params={
-                "address": leader_unit.public_address,
-                'i-really-mean-it': True
-            })
-
-        assert action.data.get("results") is not None, (
-            "Force quorum using partition of action failed: {}"
-            .format(action.data))
-        logging.debug(
-            "Results from running 'force-quorum' command ...\n{}".format(
-                action.data))
-
-        logging.info("Wait till model is idle ...")
-        try:
-            zaza.model.block_until_all_units_idle()
-        except zaza.model.UnitError:
-            self.resolve_update_status_errors()
-            zaza.model.block_until_all_units_idle()
-
-        # Unblock all traffic across mysql instances
-        for unit in zaza.model.get_units(self.application):
-            cmd = "sudo iptables -F"
-            zaza.model.async_run_on_unit(unit, cmd)
-
-        logging.info("Wait for application states ...")
-        for unit in zaza.model.get_units(self.application):
-            zaza.model.run_on_unit(unit.entity_id, "hooks/update-status")
-        test_config = lifecycle_utils.get_charm_config(fatal=False)
-        zaza.model.wait_for_application_states(
-            states=test_config.get("target_deploy_status", {}))
-
 
 class MySQL8MigrationTests(MySQLBaseTest):
     """Percona Cluster to MySQL InnoDB Cluster Tests."""
@@ -928,6 +861,77 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
         assert action.data.get("results") is not None, (
             "Remove instance action failed: No results: {}"
             .format(action.data))
+
+
+class MySQLInnoDBClusterPartitionTest(MySQLBaseTest):
+    """MySQL parition handling."""
+
+    def test_850_force_quorum_using_partition_of(self):
+        """Force quorum using partition of instance with given address.
+
+        After outage, cluster can end up without quorum. Force it.
+        """
+        logging.info("Wait till model is idle ...")
+        zaza.model.block_until_all_units_idle()
+
+        # Block all traffic across mysql instances: 0<-1, 1<-2 and 2<-0
+        mysql_units = [unit for unit in zaza.model.get_units(self.application)]
+        no_of_units = len(mysql_units)
+        for index, unit in enumerate(mysql_units):
+            next_unit = mysql_units[(index+1) % no_of_units]
+            ip_address = next_unit.public_address
+            cmd = "sudo iptables -A INPUT -s {} -j DROP".format(ip_address)
+            zaza.model.async_run_on_unit(unit, cmd)
+
+        logging.info(
+            "Wait till all {} units are in state 'blocked' ..."
+            .format(self.application))
+        for unit in zaza.model.get_units(self.application):
+            zaza.model.block_until_unit_wl_status(
+                unit.entity_id,
+                'blocked',
+                negate_match=True)
+
+        logging.info("Wait till model is idle ...")
+        zaza.model.block_until_all_units_idle()
+
+        logging.info("Execute force-quorum-using-partition-of action ...")
+
+        # Select "quorum leader" unit
+        leader_unit = mysql_units[0]
+        action = zaza.model.run_action(
+            leader_unit.entity_id,
+            "force-quorum-using-partition-of",
+            action_params={
+                "address": leader_unit.public_address,
+                'i-really-mean-it': True
+            })
+
+        assert action.data.get("results") is not None, (
+            "Force quorum using partition of action failed: {}"
+            .format(action.data))
+        logging.debug(
+            "Results from running 'force-quorum' command ...\n{}".format(
+                action.data))
+
+        logging.info("Wait till model is idle ...")
+        try:
+            zaza.model.block_until_all_units_idle()
+        except zaza.model.UnitError:
+            self.resolve_update_status_errors()
+            zaza.model.block_until_all_units_idle()
+
+        # Unblock all traffic across mysql instances
+        for unit in zaza.model.get_units(self.application):
+            cmd = "sudo iptables -F"
+            zaza.model.async_run_on_unit(unit, cmd)
+
+        logging.info("Wait for application states ...")
+        for unit in zaza.model.get_units(self.application):
+            zaza.model.run_on_unit(unit.entity_id, "hooks/update-status")
+        test_config = lifecycle_utils.get_charm_config(fatal=False)
+        zaza.model.wait_for_application_states(
+            states=test_config.get("target_deploy_status", {}))
 
 
 class MySQLRouterTests(test_utils.OpenStackBaseTest):


### PR DESCRIPTION
Currently the new partition test_110 is breaking on master due to the
test landing before the charm PR which implemented the change [0] has
landed.

Move the partition test to its own class which can be added as a target
in the charm's tests.yaml. This will not affect master and can be
trivially updated in [0].

[0] https://review.opendev.org/c/openstack/charm-mysql-innodb-cluster/+/779427