### PR TITLE
Get OpenStack codename from /etc/openstack-release

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1770,9 +1770,14 @@ def get_openstack_release(application, model_name=None):
     units = model.get_units(application, model_name=model_name)
     for unit in units:
         cmd = 'cat /etc/openstack-release | grep OPENSTACK_CODENAME'
-        out = juju_utils.remote_run(unit.entity_id, cmd, model_name=model_name)
-        codename = out.split('=')[1].strip()
-        versions.append(codename)
+        try:
+            out = juju_utils.remote_run(unit.entity_id, cmd,
+                                        model_name=model_name)
+        except model.CommandRunFailed:
+            logging.info('Fall back to version check for OpenStack codename')
+        else:
+            codename = out.split('=')[1].strip()
+            versions.append(codename)
     if len(set(versions)) == 0:
         return None
     elif len(set(versions)) > 1:

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1774,7 +1774,7 @@ def get_openstack_release(application, model_name=None):
             out = juju_utils.remote_run(unit.entity_id, cmd,
                                         model_name=model_name)
         except model.CommandRunFailed:
-            logging.info('Fall back to version check for OpenStack codename')
+            logging.debug('Fall back to version check for OpenStack codename')
         else:
             codename = out.split('=')[1].strip()
             versions.append(codename)

--- a/zaza/openstack/utilities/os_versions.py
+++ b/zaza/openstack/utilities/os_versions.py
@@ -36,6 +36,7 @@ UBUNTU_OPENSTACK_RELEASE = OrderedDict([
     ('eoan', 'train'),
     ('focal', 'ussuri'),
     ('groovy', 'victoria'),
+    ('hirsute', 'wallaby'),
 ])
 
 
@@ -69,7 +70,8 @@ OPENSTACK_RELEASES_PAIRS = [
     'bionic_queens', 'bionic_rocky', 'cosmic_rocky',
     'bionic_stein', 'disco_stein', 'bionic_train',
     'eoan_train', 'bionic_ussuri', 'focal_ussuri',
-    'focal_victoria', 'groovy_victoria']
+    'focal_victoria', 'groovy_victoria',
+    'focal_wallaby', 'hirsute_wallaby']
 
 SWIFT_CODENAMES = OrderedDict([
     ('diablo',


### PR DESCRIPTION
In newer versions of Ubuntu and the Cloud Archive (currently Hirsute,
Wallaby, and above), there is an openstack-release package that, if
installed, specifies the current OpenStack release in
/etc/openstack-release.

Also adds wallaby definitions to non-version definitions in
os_versions.py.

Fixes #560