### PR TITLE
Restart blocked mysql routers (#565)

### DIFF
--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -573,6 +573,32 @@ class BaseCharmTest(unittest.TestCase):
         return self.test_config.get('tests_options', {}).get(
             '.'.join(caller_path + [key]), default)
 
+    def get_applications_with_substring_in_name(self, substring):
+        """Get applications with substring in name.
+
+        :param substring: String to search for in application names
+        :type substring: str
+        :returns: List of matching applictions
+        :rtype: List
+        """
+        status = model.get_status().applications
+        applications = []
+        for application in status.keys():
+            if substring in application:
+                applications.append(application)
+        return applications
+
+    def run_update_status_hooks(self, units):
+        """Run update status hooks on units.
+
+        :param units: List of unit names or unit.entity_id
+        :type units: List[str]
+        :returns: None
+        :rtype: None
+        """
+        for unit in units:
+            model.run_on_unit(unit, "hooks/update-status")
+
 
 class OpenStackBaseTest(BaseCharmTest):
     """Generic helpers for testing OpenStack API charms."""


### PR DESCRIPTION
LP Bug #1918953 [0] was resolved on the mysql-innodb-cluster side using coordinated delayed action. Since then we have seen a similar issue in CI [1] after the pause and resume test. Mysql-router hangs with:
2021-04-21 20:42:05 metadata_cache WARNING [7f3f968d5700] Instance '192.168.254.18:3306' [72b4ac2c-a2dd-11eb-82a5-fa163e5a4b7e] of replicaset 'default' is unreachable. Increasing metadata cache refresh frequency.

This cannot be fixed from the cluster side. I will be looking into solutions on the mysql-rotuer side. But in the meantime, to unblock the mysql-innodb-cluster gate this change restarts blocked MySQL routers.

[0] https://bugs.launchpad.net/charm-mysql-router/+bug/1918953
[1] https://openstack-ci-reports.ubuntu.com/artifacts/test_charm_pipeline_func_full/openstack/charm-mysql-innodb-cluster/786514/3/8479/consoleText.test_charm_func_full_11494.txt