### PR TITLE
Additions for the Octavia Upgrade tests

### DIFF
--- a/zaza/openstack/utilities/exceptions.py
+++ b/zaza/openstack/utilities/exceptions.py
@@ -15,6 +15,12 @@
 """Module of exceptions that zaza may raise."""
 
 
+class InvalidTestConfig(Exception):
+    """Exception when the test configuration is invalid."""
+
+    pass
+
+
 class MissingOSAthenticationException(Exception):
     """Exception when some data needed to authenticate is missing."""
 


### PR DESCRIPTION
These are additions to make the Octavia Upgrade tests in the
charmed-openstack-tests repository a little easier to specify.  Also
depends on the zaza change [1].

[1] https://github.com/openstack-charmers/zaza/pull/442