### PR TITLE
added glance functional test for image-conversion config

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -550,7 +550,8 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             backend=None,
             disk_format='qcow2',
             visibility='public',
-            container_format='bare')
+            container_format='bare',
+            force_import=False)
 
     def test_create_image_pass_directory(self):
         glance_mock = mock.MagicMock()
@@ -574,7 +575,8 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             backend=None,
             disk_format='qcow2',
             visibility='public',
-            container_format='bare')
+            container_format='bare',
+            force_import=False)
         self.gettempdir.assert_not_called()
 
     def test_create_ssh_key(self):


### PR DESCRIPTION
Functional test for image-conversion feature added in https://review.opendev.org/c/openstack/charm-glance/+/792065

Test does:
* Validates that test runs only on supported versions
* Enables config image-conversion 
* Wait for unit to settle
* Creates, stages and imports an image and waits until it's imported
* Assert that image format is `raw`