### PR TITLE
gss: Log Keystone service catalog on failure

### DIFF
--- a/zaza/openstack/charm_tests/glance_simplestreams_sync/setup.py
+++ b/zaza/openstack/charm_tests/glance_simplestreams_sync/setup.py
@@ -18,9 +18,31 @@
 
 import logging
 import tenacity
+import pprint
 
 import zaza.model as zaza_model
 import zaza.openstack.utilities.generic as generic_utils
+import zaza.openstack.utilities.openstack as openstack_utils
+
+
+def _get_catalog():
+    """Retrieve the Keystone service catalog.
+
+    :returns: The raw Keystone service catalog.
+    :rtype: List[Dict]
+    """
+    keystone_session = openstack_utils.get_overcloud_keystone_session()
+    keystone_client = openstack_utils.get_keystone_session_client(
+        keystone_session)
+
+    token = keystone_session.get_token()
+    token_data = keystone_client.tokens.get_token_data(token)
+
+    if 'catalog' not in token_data['token']:
+        raise ValueError('catalog not in token data: "{}"'
+                         .format(pprint.pformat(token_data)))
+
+    return token_data['token']['catalog']
 
 
 def sync_images():
@@ -31,17 +53,27 @@ def sync_images():
     deployment.
     """
     logging.info("Synchronising images using glance-simplestreams-sync")
-    for attempt in tenacity.Retrying(
-            stop=tenacity.stop_after_attempt(3),
-            wait=tenacity.wait_exponential(
-                multiplier=1, min=2, max=10),
-            reraise=True):
-        with attempt:
-            generic_utils.assertActionRanOK(
-                zaza_model.run_action_on_leader(
-                    "glance-simplestreams-sync",
-                    "sync-images",
-                    raise_on_failure=True,
-                    action_params={},
+
+    catalog = None
+    try:
+        for attempt in tenacity.Retrying(
+                stop=tenacity.stop_after_attempt(3),
+                wait=tenacity.wait_exponential(
+                    multiplier=1, min=2, max=10),
+                reraise=True):
+            with attempt:
+                # Proactively retrieve the Keystone service catalog so that we
+                # can log it in the event of a failure.
+                catalog = _get_catalog()
+                generic_utils.assertActionRanOK(
+                    zaza_model.run_action_on_leader(
+                        "glance-simplestreams-sync",
+                        "sync-images",
+                        raise_on_failure=True,
+                        action_params={},
+                    )
                 )
-            )
+    except Exception:
+        logging.info('Contents of Keystone service catalog: "{}"'
+                     .format(pprint.pformat(catalog)))
+        raise


### PR DESCRIPTION
The simplestreams service relies on the Keystone Service catalog.
To help debug any issues occurring during test execution, log the
contents of the Keystone service catalog in the event of failure.

Related-Bug: #1930654