### PR TITLE
octavia: Grant role to ensure access to LBAASv2 API

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -136,9 +136,11 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         cls.keystone_client = ObjectRetrierWraps(
             openstack_utils.get_keystone_session_client(cls.keystone_session))
 
-        # add role to admin user for the duration of the test
-        grant_role_current_user(cls.keystone_client, cls.keystone_session,
-                                LBAAS_ADMIN_ROLE)
+        if (openstack_utils.get_os_release() >=
+                openstack_utils.get_os_release('focal_wallaby')):
+            # add role to admin user for the duration of the test
+            grant_role_current_user(cls.keystone_client, cls.keystone_session,
+                                    LBAAS_ADMIN_ROLE)
 
         cls.neutron_client = ObjectRetrierWraps(
             openstack_utils.get_neutron_session_client(cls.keystone_session))
@@ -206,9 +208,12 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         # allow resource cleanup to be run multiple times
         self.loadbalancers = []
 
-        # revoke role from admin user added by this test
-        revoke_role_current_user(self.keystone_client, self.keystone_session,
-                                 LBAAS_ADMIN_ROLE)
+        if (openstack_utils.get_os_release() >=
+                openstack_utils.get_os_release('focal_wallaby')):
+            # revoke role from admin user added by this test
+            revoke_role_current_user(self.keystone_client,
+                                     self.keystone_session,
+                                     LBAAS_ADMIN_ROLE)
 
         for fip in self.fips:
             self.neutron_client.delete_floatingip(fip)

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -679,17 +679,21 @@ class OctaviaTests(BasePolicydSpecialization):
         cls.keystone_client = ObjectRetrierWraps(
             openstack_utils.get_keystone_session_client(cls.keystone_session))
 
-        # add role to admin user for the duration of the test
-        octavia_tests.grant_role_current_user(
-            cls.keystone_client, cls.keystone_session,
-            octavia_tests.LBAAS_ADMIN_ROLE)
+        if (openstack_utils.get_os_release() >=
+                openstack_utils.get_os_release('focal_wallaby')):
+            # add role to admin user for the duration of the test
+            octavia_tests.grant_role_current_user(
+                cls.keystone_client, cls.keystone_session,
+                octavia_tests.LBAAS_ADMIN_ROLE)
 
     def resource_cleanup(self):
         """Restore changes made by test."""
-        # revoke role from admin user added by this test
-        octavia_tests.revoke_role_current_user(
-            self.keystone_client, self.keystone_session,
-            octavia_tests.LBAAS_ADMIN_ROLE)
+        if (openstack_utils.get_os_release() >=
+                openstack_utils.get_os_release('focal_wallaby')):
+            # revoke role from admin user added by this test
+            octavia_tests.revoke_role_current_user(
+                self.keystone_client, self.keystone_session,
+                octavia_tests.LBAAS_ADMIN_ROLE)
 
     def get_client_and_attempt_operation(self, ip):
         """Attempt to list available provider drivers.


### PR DESCRIPTION
Starting with OpenStack Wallaby the LBAASv2 API will require
authentication with system scoped token unless the user has
the 'load-balancer_admin' role.

Grant role on test setup, and remove it again on clean-up.