### PR TITLE
Extend trilio snapshot timeout

### DIFF
--- a/zaza/openstack/charm_tests/trilio/tests.py
+++ b/zaza/openstack/charm_tests/trilio/tests.py
@@ -262,7 +262,7 @@ class WorkloadmgrCLIHelper(object):
 
         retryer = tenacity.Retrying(
             wait=tenacity.wait_exponential(multiplier=1, max=30),
-            stop=tenacity.stop_after_delay(720),
+            stop=tenacity.stop_after_delay(900),
             reraise=True,
         )
 


### PR DESCRIPTION
Extend trilio snapshot timeout, closes issue #593 .