### PR TITLE
Ensure application name is passed in scenario tests

### DIFF
--- a/zaza/openstack/charm_tests/trilio/tests.py
+++ b/zaza/openstack/charm_tests/trilio/tests.py
@@ -329,7 +329,7 @@ class TrilioBaseTest(test_utils.OpenStackBaseTest):
     @classmethod
     def setUpClass(cls):
         """Run class setup for running tests."""
-        super().setUpClass()
+        super().setUpClass(application_name=cls.application_name)
         cls.cinder_client = openstack_utils.get_cinder_session_client(
             cls.keystone_session
         )
@@ -474,15 +474,19 @@ class TrilioDataMoverBaseTest(TrilioBaseTest):
 
 class TrilioDataMoverNFSTest(TrilioDataMoverBaseTest, TrilioGhostNFSShareTest):
     """Tests for Trilio Data Mover charm backed by NFS."""
+    application_name = "trilio-data-mover"
 
 
 class TrilioDataMoverS3Test(TrilioDataMoverBaseTest):
     """Tests for Trilio Data Mover charm backed by S3."""
+    application_name = "trilio-data-mover"
 
 
 class TrilioWLMNFSTest(TrilioWLMBaseTest, TrilioGhostNFSShareTest):
     """Tests for Trilio WLM charm backed by NFS."""
+    application_name = "trilio-wlm"
 
 
 class TrilioWLMS3Test(TrilioWLMBaseTest):
     """Tests for Trilio WLM charm backed by S3."""
+    application_name = "trilio-wlm"

--- a/zaza/openstack/charm_tests/trilio/tests.py
+++ b/zaza/openstack/charm_tests/trilio/tests.py
@@ -474,19 +474,23 @@ class TrilioDataMoverBaseTest(TrilioBaseTest):
 
 class TrilioDataMoverNFSTest(TrilioDataMoverBaseTest, TrilioGhostNFSShareTest):
     """Tests for Trilio Data Mover charm backed by NFS."""
+
     application_name = "trilio-data-mover"
 
 
 class TrilioDataMoverS3Test(TrilioDataMoverBaseTest):
     """Tests for Trilio Data Mover charm backed by S3."""
+
     application_name = "trilio-data-mover"
 
 
 class TrilioWLMNFSTest(TrilioWLMBaseTest, TrilioGhostNFSShareTest):
     """Tests for Trilio WLM charm backed by NFS."""
+
     application_name = "trilio-wlm"
 
 
 class TrilioWLMS3Test(TrilioWLMBaseTest):
     """Tests for Trilio WLM charm backed by S3."""
+
     application_name = "trilio-wlm"


### PR DESCRIPTION
When running Trilio tests in a scenario test there is no 'charm_name'
so the application name needs to be explicitly set when calling
the setup class otherwise some config, such as lead_unit, is
missing.