### PR TITLE
Wait between actions on OpenStack upgrade

### DIFF
--- a/zaza/openstack/utilities/openstack_upgrade.py
+++ b/zaza/openstack/utilities/openstack_upgrade.py
@@ -132,12 +132,23 @@ def action_upgrade_apps(applications, model_name=None):
             status=status,
             model_name=model_name)
 
+        # NOTE(lourot): we're more likely to time out while waiting for the
+        # action's result if we launch an action while the model is still
+        # executing. Thus it's safer to wait for the model to settle between
+        # actions.
+        zaza.model.block_until_all_units_idle(model_name)
         pause_units(hacluster_units, model_name=model_name)
+
+        zaza.model.block_until_all_units_idle(model_name)
         pause_units(target, model_name=model_name)
 
+        zaza.model.block_until_all_units_idle(model_name)
         action_unit_upgrade(target, model_name=model_name)
 
+        zaza.model.block_until_all_units_idle(model_name)
         resume_units(target, model_name=model_name)
+
+        zaza.model.block_until_all_units_idle(model_name)
         resume_units(hacluster_units, model_name=model_name)
 
         done.extend(target)


### PR DESCRIPTION
We're more likely to time out while waiting for the
action's result if we launch an action while the
model is still executing. Thus it's safer to wait
for the model to settle between actions.

Validated locally:

```
$ tox -e openstack-upgrade kitchen-sink-focal-ussuri
[...]
  Deploy Bundle:
    Start: 1626813365.993568
    Finish: 1626813550.7522993
    Elapsed Time: 184.75873136520386
    PCT Of Run Time: 2
  Prepare Environment:
    Start: 1626813363.8050616
    Finish: 1626813365.4636593
    Elapsed Time: 1.658597707748413
    PCT Of Run Time: 1
  Test zaza.openstack.charm_tests.openstack_upgrade.tests.OpenStackUpgradeTestsFocalUssuri:
    Start: 1626818712.0522335
    Finish: 1626822851.7874122
    Elapsed Time: 4139.73517870903
    PCT Of Run Time: 44
  Test zaza.openstack.charm_tests.openstack_upgrade.tests.WaitForMySQL:
    Start: 1626818711.1111934
    Finish: 1626818712.0521748
    Elapsed Time: 0.940981388092041
    PCT Of Run Time: 1
  Wait for Deployment:
    Start: 1626813550.7523944
    Finish: 1626816112.8488872
    Elapsed Time: 2562.096492767334
    PCT Of Run Time: 28
Metadata: {}

_____________________________________________________________________________________________________ summary _____________________________________________________________________________________________________
  openstack-upgrade: commands succeeded
  congratulations :)
```