### PR TITLE
Removed unneeded dependency to distro-info

### DIFF
--- a/pip.sh
+++ b/pip.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+pip install pip==20.2.3
+pip install "$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ python-novaclient
 python-octaviaclient
 python-swiftclient
 tenacity
-distro-info
 paramiko
 
 # Documentation requirements

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ minversion = 3.2.0
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 install_command =
-  pip install {opts} {packages}
+  {toxinidir}/pip.sh install {opts} {packages}
 
 commands = nosetests --with-coverage --cover-package=zaza.openstack {posargs} {toxinidir}/unit_tests
 


### PR DESCRIPTION
distro-info hasn't been maintained for 8 years and pip is
now failing to fetch it on Python 3.8.

This dependency seems to have been introduced by accident
in 22e7ffc.

Without this fix, the pip failure is visible in #607 