### PR TITLE
Fix ResolutionImpossible on tox invocation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ paramiko
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
-git+https://github.com/openstack-charmers/zaza#egg=zaza
+git+https://github.com/openstack-charmers/zaza@stable/21.04#egg=zaza
 
 # Newer versions require a Rust compiler to build, see
 # * https://github.com/openstack-charmers/zaza/issues/421

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_require = [
     'python-ceilometerclient',
     'python-cinderclient<6.0.0',
     'python-swiftclient<3.9.0',
-    'zaza@git+https://github.com/openstack-charmers/zaza.git#egg=zaza',
+    'zaza@git+https://github.com/openstack-charmers/zaza.git@stable/21.04#egg=zaza',
 ]
 
 tests_require = [


### PR DESCRIPTION
See openstack-charmers/release-tools#151

Without this fix, 21.04 charm gates now fail with

```
The conflict is caused by:
    The user requested zaza 0.0.2.dev1 (from git+https://github.com/openstack-charmers/zaza.git@stable/21.04#egg=zaza)
    zaza-openstack 0.0.1.dev1 depends on zaza 0.0.2.dev1 (from git+https://github.com/openstack-charmers/zaza.git
```

Visible here: https://review.opendev.org/c/openstack/charm-neutron-api/+/802471