### PR TITLE
Bump trilio snapshot create timeout

### DIFF
--- a/zaza/openstack/charm_tests/trilio/tests.py
+++ b/zaza/openstack/charm_tests/trilio/tests.py
@@ -262,7 +262,7 @@ class WorkloadmgrCLIHelper(object):
 
         retryer = tenacity.Retrying(
             wait=tenacity.wait_exponential(multiplier=1, max=30),
-            stop=tenacity.stop_after_delay(900),
+            stop=tenacity.stop_after_delay(1200),
             reraise=True,
         )
 


### PR DESCRIPTION
A recent testrun failed when using an S3 backend because the
snapshot creation timed out. The time out is set to 900s but it
took 959s.