### PR TITLE
Add support for restarting and then retesting manila share services

### DIFF
--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -16,11 +16,14 @@
 
 """Encapsulate Manila Ganesha testing."""
 
+import logging
+
 from zaza.openstack.charm_tests.manila_ganesha.setup import (
     MANILA_GANESHA_TYPE_NAME,
 )
 
 import zaza.openstack.charm_tests.manila.tests as manila_tests
+import zaza.model
 
 
 class ManilaGaneshaTests(manila_tests.ManilaBaseTest):
@@ -33,3 +36,19 @@ class ManilaGaneshaTests(manila_tests.ManilaBaseTest):
         cls.share_name = 'cephnfsshare1'
         cls.share_type_name = MANILA_GANESHA_TYPE_NAME
         cls.share_protocol = 'nfs'
+
+    def _restart_share_instance(self):
+        logging.info('Restarting manila-share and nfs-ganesha')
+        # It would be better for thie to derive the application name,
+        # manila-ganesha-az1, from deployed instances fo the manila-ganesha
+        # charm; however, that functionality isn't present yet in zaza, so
+        # this is hard coded to the application name used in that charm's
+        # test bundles.
+        for unit in zaza.model.get_units('manila-ganesha-az1'):
+            # While we really only need to run this on the machine hosting
+            # nfs-ganesha and manila-share, running it everywhere isn't
+            # harmful. Pacemaker handles restarting the services
+            zaza.model.run_on_unit(
+                unit.entity_id,
+                "systemctl stop manila-share nfs-ganesha")
+        return True


### PR DESCRIPTION
In this change, a charm test that subclasses the ManilaBaseTest
class can also opt-in to re-validating a share after restarting
the share services by overriding the _restart_share_instance
method.

This stable backport is being tested and run in https://review.opendev.org/c/openstack/charm-manila-ganesha/+/802934