### PR TITLE
Adds tests for NRPE checks in Manila

### DIFF
--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -99,14 +99,12 @@ class ManilaTests(test_utils.OpenStackBaseTest):
             )
 
         for attempt in tenacity.Retrying(
-            retry=tenacity.retry_if_result(lambda ret: ret is not None),
-            wait=tenacity.wait_fixed(120),
-            stop=tenacity.stop_after_attempt(2)
+            wait=tenacity.wait_fixed(20),
+            stop=tenacity.stop_after_attempt(2),
+            reraise=True
         ):
             with attempt:
                 ret = generic_utils.check_commands_on_units(cmds, units)
-                if ret:
-                    logging.info(ret)
                 self.assertIsNone(ret, msg=ret)
 
 


### PR DESCRIPTION
Adds a test to ensure that Manila units related to NRPE get service check files created.

Closes-Bug: #1925977