### PR TITLE
Add certificate check for Ceph dashboard

### DIFF
--- a/zaza/openstack/charm_tests/ceph/dashboard/setup.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/setup.py
@@ -1,0 +1,34 @@
+# Copyright 2021 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Code for setting up Ceph Dashboard."""
+
+import logging
+
+import zaza.model
+import zaza.openstack.utilities.openstack
+
+
+def check_dashboard_cert(model_name=None):
+    """Wait for Dashboard to be ready.
+
+    :param model_name: Name of model to query.
+    :type model_name: str
+    """
+    logging.info("Check dashbaord Waiting for cacert")
+    zaza.openstack.utilities.openstack.block_until_ca_exists(
+        'ceph-dashboard',
+        'CERTIFICATE',
+        model_name=model_name)
+    zaza.model.block_until_all_units_idle(model_name=model_name)

--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -15,12 +15,11 @@
 """Encapsulating `ceph-dashboard` testing."""
 
 import collections
-import os
 import requests
 
 import zaza
 import zaza.openstack.charm_tests.test_utils as test_utils
-import zaza.utilities.deployment_env as deployment_env
+import zaza.openstack.utilities.openstack as openstack_utils
 
 
 class CephDashboardTest(test_utils.BaseCharmTest):
@@ -34,21 +33,8 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         """Run class setup for running ceph dashboard tests."""
         super().setUpClass()
         cls.application_name = 'ceph-dashboard'
-        cls.local_ca_cert = cls.collect_ca()
-
-    @classmethod
-    def collect_ca(cls):
-        """Collect CA from ceph-dashboard unit."""
-        local_ca_cert = os.path.join(
-            deployment_env.get_tmpdir(),
-            os.path.basename(cls.REMOTE_CERT_FILE))
-        if not os.path.isfile(local_ca_cert):
-            units = zaza.model.get_units(cls.application_name)
-            zaza.model.scp_from_unit(
-                units[0].entity_id,
-                cls.REMOTE_CERT_FILE,
-                local_ca_cert)
-        return local_ca_cert
+        cls.local_ca_cert = openstack_utils.get_remote_ca_cert_file(
+            cls.application_name)
 
     def test_dashboard_units(self):
         """Check dashboard units are configured correctly."""


### PR DESCRIPTION
Add setup step for the dashboard which will block until the
certificates are present and the model is idle. This is to prevent
the tests from continuing when the certificates are not ready.
Also up CephDashboardTest to use standard tools for collecting
ca cert.