### PR TITLE
Add neutron setup for VLAN provider network

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -58,11 +58,12 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
 
         self.network = {
             "network": {"id": "network_id",
-                              "name": self.ext_net,
-                              "tenant_id": self.project_id,
-                              "router:external": True,
-                              "provider:physical_network": "physnet1",
-                              "provider:network_type": "flat"}}
+                        "name": self.ext_net,
+                        "router:external": True,
+                        "shared": False,
+                        "tenant_id": self.project_id,
+                        "provider:physical_network": "physnet1",
+                        "provider:network_type": "flat"}}
 
         self.networks = {
             "networks": [self.network["network"]]}
@@ -157,12 +158,12 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.neutronclient.create_address_scope.assert_called_once_with(
             address_scope_msg)
 
-    def test_create_external_network(self):
+    def test_create_provider_network(self):
         self.patch_object(openstack_utils, "get_net_uuid")
         self.get_net_uuid.return_value = self.net_uuid
 
         # Already exists
-        network = openstack_utils.create_external_network(
+        network = openstack_utils.create_provider_network(
             self.neutronclient, self.project_id)
         self.assertEqual(network, self.network["network"])
         self.neutronclient.create_network.assert_not_called()
@@ -172,7 +173,7 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             "networks": []}
         network_msg = copy.deepcopy(self.network)
         network_msg["network"].pop("id")
-        network = openstack_utils.create_external_network(
+        network = openstack_utils.create_provider_network(
             self.neutronclient, self.project_id)
         self.assertEqual(network, self.network["network"])
         self.neutronclient.create_network.assert_called_once_with(

--- a/zaza/openstack/charm_tests/neutron/setup.py
+++ b/zaza/openstack/charm_tests/neutron/setup.py
@@ -44,6 +44,13 @@ OVERCLOUD_NETWORK_CONFIG = {
     "subnetpool_prefix": "192.168.0.0/16",
 }
 
+OVERCLOUD_PROVIDER_VLAN_NETWORK_CONFIG = {
+    "provider_vlan_net_name": "provider_vlan",
+    "provider_vlan_subnet_name": "provider_vlan_subnet",
+    "provider_vlan_cidr": "10.42.33.0/24",
+    "provider_vlan_id": "2933",
+}
+
 # The undercloud network configuration settings are substrate specific to
 # the environment where the tests are being executed. These settings may be
 # overridden by environment variables. See the doc string documentation for
@@ -110,8 +117,29 @@ def basic_overcloud_network(limit_gws=None):
                         ' charm network configuration.'
                         .format(provider_type))
 
-    # Confugre the overcloud network
+    # Configure the overcloud network
     network.setup_sdn(network_config, keystone_session=keystone_session)
+
+
+def vlan_provider_overcloud_network():
+    """Run setup to create a VLAN provider network."""
+    cli_utils.setup_logging()
+
+    # Get network configuration settings
+    network_config = {}
+    # Declared overcloud settings
+    network_config.update(OVERCLOUD_NETWORK_CONFIG)
+    # Declared provider vlan overcloud settings
+    network_config.update(OVERCLOUD_PROVIDER_VLAN_NETWORK_CONFIG)
+    # Environment specific settings
+    network_config.update(generic_utils.get_undercloud_env_vars())
+
+    # Get keystone session
+    keystone_session = openstack_utils.get_overcloud_keystone_session()
+
+    # Configure the overcloud network
+    network.setup_sdn_provider_vlan(network_config,
+                                    keystone_session=keystone_session)
 
 
 # Configure function to get one gateway with external network


### PR DESCRIPTION
This adds a new setup function that will setup a VLAN provider network.
It can be called by tests.yaml after basic_overcloud_network:
- zaza.openstack.charm_tests.neutron.setup.basic_overcloud_network
- zaza.openstack.charm_tests.neutron.setup.vlan_provider_overcloud_network