### PR TITLE
Pin coverage < 6.0.0 for Py3.5 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ flake8>=2.2.4
 flake8-docstrings
 flake8-per-file-ignores
 pydocstyle<4.0.0
-coverage
+coverage<6.0.0  # coverage 6.0+ drops support for py3.5/py2.7
 mock>=1.2
 nose>=1.3.7
 pbr>=1.8.0,<1.9.0


### PR DESCRIPTION
Coverage dropped py3.5 suppot at 6.0.0 and zaza.openstack.tests
currently support Xenial.