### PR TITLE
Fix test for cinder-lvm

### DIFF
--- a/zaza/openstack/charm_tests/cinder_lvm/tests.py
+++ b/zaza/openstack/charm_tests/cinder_lvm/tests.py
@@ -91,7 +91,7 @@ class CinderLVMTest(test_utils.OpenStackBaseTest):
         self.assertTrue(test_vol)
 
         host = getattr(test_vol, 'os-vol-host-attr:host').split('#')[0]
-        self.assertTrue(host.startswith('cinder@LVM'))
+        self.assertIn('@LVM', host)
 
     def test_volume_overwrite(self):
         """Test creating a volume by overwriting one on a loop device."""


### PR DESCRIPTION
Since the charm is now marked stateful, the 'host' attribute of a volume is mangled differently. This change makes the test more robust against future changes as well.