### PR TITLE
Point to stable/21.10 version of zaza

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ paramiko
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
-git+https://github.com/openstack-charmers/zaza#egg=zaza
+git+https://github.com/openstack-charmers/zaza@stable/21.10#egg=zaza
 
 # Newer versions require a Rust compiler to build, see
 # * https://github.com/openstack-charmers/zaza/issues/421

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_require = [
     'python-ceilometerclient',
     'python-cinderclient<6.0.0',
     'python-swiftclient<3.9.0',
-    'zaza@git+https://github.com/openstack-charmers/zaza.git#egg=zaza',
+    'zaza@git+https://github.com/openstack-charmers/zaza.git@stable/21.10#egg=zaza',
 ]
 
 tests_require = [


### PR DESCRIPTION
This is for the stable/21.10 version of zaza-openstack-tests, so that it
uses the stable/21.10 version of zaza.  This also (hopefully) resolves
pip dependency issues between requirements specifying the stable branch
and the z-o-t lib specifying the master branch.