### PR TITLE
Favor the V3 volume endpoint for tempest config

### DIFF
--- a/zaza/openstack/charm_tests/tempest/utils.py
+++ b/zaza/openstack/charm_tests/tempest/utils.py
@@ -286,7 +286,8 @@ def _add_cinder_config(ctxt, keystone_session):
     :returns: None
     :rtype: None
     """
-    volume_types = ['volumev2', 'volumev3']
+    # The most most recent API version must be listed first.
+    volume_types = ['volumev3', 'volumev2']
     keystone_client = openstack_utils.get_keystone_session_client(
         keystone_session)
     for volume_type in volume_types:


### PR DESCRIPTION
If the V3 volume endpoint is available, use it for tempest testing.
The V2 volume endpoint is removed in OpenStack Xena, so this allows
us to use the latest available endpoint.