### PR TITLE
Swift proxy remove devices test added

### DIFF
--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -95,6 +95,54 @@ class SwiftProxyTests(test_utils.OpenStackBaseTest):
 class SwiftProxyMultiZoneTests(test_utils.OpenStackBaseTest):
     """Tests specific to swift proxy in multi zone environment."""
 
+    RESOURCE_PREFIX = 'zaza-swift-proxy-multizone-tests'
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running tests."""
+        cls.region1_model_alias = 'swift_gr_region1'
+        cls.region1_proxy_app = 'swift-proxy-region1'
+        super(SwiftProxyMultiZoneTests, cls).setUpClass(
+            application_name=cls.region1_proxy_app,
+            model_alias=cls.region1_model_alias)
+        cls.region1_model_name = cls.model_aliases[cls.region1_model_alias]
+        cls.storage_topology = swift_utils.get_swift_storage_topology(
+            model_name=cls.region1_model_name)
+        cls.swift_session = openstack_utils.get_keystone_session_from_relation(
+            cls.region1_proxy_app,
+            model_name=cls.region1_model_name)
+        cls.swift_region1 = openstack_utils.get_swift_session_client(
+            cls.swift_session,
+            region_name='RegionOne')
+
+    @classmethod
+    @tenacity.retry(
+        wait=tenacity.wait_exponential(multiplier=1, min=16, max=600),
+        reraise=True,
+        stop=tenacity.stop_after_attempt(10))
+    def tearDown(cls):
+        """Remove test resources.
+
+        The retry decorator is needed as it is luck of the draw as to whether
+        a delete of a newly created container will result in a 404. Retrying
+        will eventually result in the delete being accepted.
+        """
+        logging.info('Running teardown')
+        resp_headers, containers = cls.swift_region1.get_account()
+        logging.info('Found containers {}'.format(containers))
+        for container in containers:
+            if not container['name'].startswith(cls.RESOURCE_PREFIX):
+                continue
+            for obj in cls.swift_region1.get_container(container['name'])[1]:
+                logging.info('Deleting object {} from {}'.format(
+                    obj['name'],
+                    container['name']))
+                cls.swift_region1.delete_object(
+                    container['name'],
+                    obj['name'])
+            logging.info('Deleting container {}'.format(container['name']))
+            cls.swift_region1.delete_container(container['name'])
+
     def test_900_remove_device_action(self):
         """Check remove-device action runs.
 
@@ -110,6 +158,16 @@ class SwiftProxyMultiZoneTests(test_utils.OpenStackBaseTest):
             })
         logging.info(action)
         self.assertEqual(action.status, "completed")
+
+        container_name, obj_name, _ = swift_utils.create_object(
+            self.swift_region1,
+            self.region1_proxy_app,
+            self.storage_topology,
+            self.RESOURCE_PREFIX,
+            model_name=self.region1_model_name)
+        # Check object is accessible from other regions proxy.
+        response = self.swift_region1.head_object(container_name, obj_name)
+        self.assertIsNotNone(response)
 
 
 class SwiftStorageTests(test_utils.OpenStackBaseTest):

--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -92,6 +92,26 @@ class SwiftProxyTests(test_utils.OpenStackBaseTest):
         self.assertEqual(action.status, "completed")
 
 
+class SwiftProxyMultiZoneTests(test_utils.OpenStackBaseTest):
+    """Tests specific to swift proxy in multi zone environment."""
+
+    def test_900_remove_device_action(self):
+        """Check remove-device action runs.
+
+        This tests destroys the environment and should be run as last.
+        """
+        logging.info('Running remove-devices action on leader')
+        action = zaza.model.run_action_on_leader(
+            'swift-proxy-region1',
+            'remove-devices',
+            action_params={
+                'ring': 'account',
+                'search-value': 'r1z3'
+            })
+        logging.info(action)
+        self.assertEqual(action.status, "completed")
+
+
 class SwiftStorageTests(test_utils.OpenStackBaseTest):
     """Tests specific to swift storage."""
 

--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -165,7 +165,7 @@ class SwiftProxyMultiZoneTests(test_utils.OpenStackBaseTest):
             self.storage_topology,
             self.RESOURCE_PREFIX,
             model_name=self.region1_model_name)
-        # Check object is accessible from other regions proxy.
+        # Check object is accessible from the region proxy.
         response = self.swift_region1.head_object(container_name, obj_name)
         self.assertIsNotNone(response)
 


### PR DESCRIPTION
A functional test for multi-zone deployment was added.

The functional test removes the devices in region1 zone3. This test requires a single region with "redundant zone 3", so it can be safely removed.
To check if cluster works after device removal - object upload and retrieval of header data are used.