### PR TITLE
Pin pyparsing to work with pinned version of aodhclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # This is necessary for Xenial builders
 # BUG: https://github.com/openstack-charmers/zaza-openstack-tests/issues/530
 lxml<4.6.3
+pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
 boto3

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ install_require = [
     'PyYAML',
     'tenacity',
     'oslo.config<6.12.0',
+    'pyparsing<3.0.0',  # pin for aodhclient which is held for py35
     'aodhclient<1.4.0',
     'gnocchiclient>=7.0.5,<8.0.0',
     'pika>=1.1.0,<2.0.0',


### PR DESCRIPTION
aodhclient is pinned at 1.4.0 and pyparsing needs to be pinned at <
3.0.0 to work with.  Note zaza also pins pyparsing as many, many modules
use pyparsing and if zaza gets installed first ti might break pip
resolution.