### PR TITLE
Support new style RMQ conf files

### DIFF
--- a/zaza/openstack/charm_tests/rabbitmq_server/utils.py
+++ b/zaza/openstack/charm_tests/rabbitmq_server/utils.py
@@ -354,9 +354,15 @@ def is_ssl_enabled_on_unit(unit, port=None):
     host = unit.public_address
     unit_name = unit.entity_id
 
-    conf_file = '/etc/rabbitmq/rabbitmq.config'
+    conf_file = '/etc/rabbitmq/rabbitmq.conf'
     conf_contents = str(generic_utils.get_file_contents(unit,
                                                         conf_file))
+    # Fallback to old style configuration file for
+    # older RMQ releases if .conf is empty/not found
+    if not conf_contents:
+        conf_file = '/etc/rabbitmq/rabbitmq.config'
+        conf_contents = str(generic_utils.get_file_contents(unit,
+                                                            conf_file))
     # Checks
     conf_ssl = 'ssl' in conf_contents
     conf_port = str(port) in conf_contents


### PR DESCRIPTION
The rabbitmq-server charm now uses INI style .conf files for
releases that support the new style of configuration.

Update SSL checks to look for this file first and then fallback
to the older .config filename if not found