### PR TITLE
Use yaml.safe_load()

### DIFF
--- a/zaza/openstack/charm_tests/neutron/tests.py
+++ b/zaza/openstack/charm_tests/neutron/tests.py
@@ -285,7 +285,7 @@ class NeutronGatewayShowActionsTest(test_utils.OpenStackBaseTest):
 
         # extract data from juju action
         action_data = action_result.data.get('results', {}).get(resource_name)
-        resources_from_action = yaml.load(action_data)
+        resources_from_action = yaml.safe_load(action_data)
 
         # pull resource IDs from expected resource list and juju action data
         expected_resource_ids = {resource['id'] for resource in resource_list}


### PR DESCRIPTION
Pyyaml>=6.0 requires to pass the Loader arg to yaml.load(), switching to
yaml.safe_load() recovers the old and expected behavior.

https://github.com/yaml/pyyaml/pull/561

Closes-Bug: #1951650