### PR TITLE
Authenticate with cinder v3 endpoint by default

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -407,7 +407,7 @@ def get_heat_session_client(session, version=1):
     return heatclient.Client(session=session, version=version)
 
 
-def get_cinder_session_client(session, version=2):
+def get_cinder_session_client(session, version=3):
     """Return cinderclient authenticated by keystone session.
 
     :param session: Keystone session object


### PR DESCRIPTION
The v3 endpoint has been supported by the charms since Pike,
and the V2 endpoint was removed in Xena, therefore it makes
to use the v3 endpoint by default at this point.