### PR TITLE
Osd add disk test

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -22,7 +22,6 @@ from os import (
     path
 )
 import requests
-import subprocess
 import tempfile
 
 import tenacity

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -39,24 +39,61 @@ import zaza.openstack.utilities.openstack as zaza_openstack
 
 
 def add_storage(unit, label, pool, size):
+    """Add storage to a Juju unit.
+
+    :param unit: The unit name (i.e: ceph-osd/0)
+    :type unit: str
+
+    :param label: The storage label (i.e: osd-devices)
+    :type label: str
+
+    :param pool: The pool on which to allocate the storage (i.e: cinder)
+    :type pool: str
+
+    :size: The size in GB of the storage to attach.
+    :type size: int
+
+    :returns: The name of the allocated storage.
+    """
     rv = subprocess.check_output(['juju', 'add-storage', unit,
                                   '{}={},{}'.format(label, pool,
                                                     str(size) + 'GB')],
-                                  stderr=subprocess.STDOUT)
+                                 stderr=subprocess.STDOUT)
     return rv.decode('UTF-8').replace('added storage ', '').split(' ')[0]
 
 
 def detach_storage(storage_name):
+    """Detach previously allocated Juju storage."""
     subprocess.check_call(['juju', 'detach-storage', storage_name])
 
 
 def remove_storage(storage_name, force=False):
+    """Remove Juju storage.
+
+    :param storage_name: The name of the previously allocated Juju storage.
+    :type storage_name: str
+
+    :param force: If False (default), require that the storage be detached
+                  before it can be removed.
+    :type force: bool
+    """
     cmd = ['juju', 'remove-storage', storage_name]
     if force:
         cmd.append('--force')
     subprocess.check_call(cmd)
 
+
 def add_loop_device(unit, size=10):
+    """Add a loopback device to a Juju unit.
+
+    :param unit: The unit name on which to create the device.
+    :type unit: str
+
+    :param size: The size in GB of the device.
+    :type size: int
+
+    :returns: The device name.
+    """
     loop_name = '/home/ubuntu/loop.img'
     truncate = 'truncate --size {}GB {}'.format(size, loop_name)
     losetup = 'losetup --find {}'.format(loop_name)
@@ -574,6 +611,7 @@ class CephTest(test_utils.OpenStackBaseTest):
         logging.debug('OK')
 
     def test_cache_device(self):
+        """Test adding a new disk with a caching device."""
         logging.info('Running add-disk action with a caching device')
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]
         for unit in osds:

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -552,13 +552,13 @@ class CephTest(test_utils.OpenStackBaseTest):
         return int(result['num_osds'])
 
     def test_cache_device(self):
-        """Test adding a new disk with a caching device."""
+    """Test adding a new disk with a caching device."""
         logging.info('Running add-disk action with a caching device')
+        mon = next(iter(zaza_model.get_units('ceph-mon'))).entity_id
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]
-        num_osds = self.get_num_osds(osds[0])
         for unit in osds:
-            zaza_model.add_storage(unit, 'cache-devices', 'cinder', 10)
-            loop_dev = zaza_utils.add_loop_device(unit, 10)
+            add_storage(unit, 'cache-devices', 'cinder', 10)
+            loop_dev = add_loop_device(unit, 10)
             action_obj = zaza_model.run_action(
                 unit_name=unit,
                 action_name='add-disk',
@@ -566,7 +566,7 @@ class CephTest(test_utils.OpenStackBaseTest):
                                'partition-size': 5}
             )
             zaza_utils.assertActionRanOK(action_obj)
-        self.assertEqual(num_osds + len(osds), self.get_num_osds(osds[0]))
+        self.assertEqual(len(osds) * 2, self.get_num_osds(mon))
 
 
 class CephRGWTest(test_utils.OpenStackBaseTest):

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -552,7 +552,7 @@ class CephTest(test_utils.OpenStackBaseTest):
         return int(result['num_osds'])
 
     def test_cache_device(self):
-    """Test adding a new disk with a caching device."""
+        """Test adding a new disk with a caching device."""
         logging.info('Running add-disk action with a caching device')
         mon = next(iter(zaza_model.get_units('ceph-mon'))).entity_id
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -35,6 +35,7 @@ import zaza.openstack.utilities.exceptions as zaza_exceptions
 import zaza.openstack.utilities.generic as zaza_utils
 import zaza.utilities.juju as juju_utils
 import zaza.openstack.utilities.openstack as zaza_openstack
+import zaza.openstack.utilities.juju as zaza_juju
 
 
 class CephLowLevelTest(test_utils.OpenStackBaseTest):
@@ -550,8 +551,8 @@ class CephTest(test_utils.OpenStackBaseTest):
         logging.info('Running add-disk action with a caching device')
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]
         for unit in osds:
-            juju_utils.add_storage(unit, 'cache-devices', 'cinder', 10)
-            loop_dev = juju_utils.add_loop_device(unit, 10)
+            zaza_juju.add_storage(unit, 'cache-devices', 'cinder', 10)
+            loop_dev = zaza_juju.add_loop_device(unit, 10)
             action_obj = zaza_model.run_action(
                 unit_name=unit,
                 action_name='add-disk',

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -38,70 +38,6 @@ import zaza.utilities.juju as juju_utils
 import zaza.openstack.utilities.openstack as zaza_openstack
 
 
-def add_storage(unit, label, pool, size):
-    """Add storage to a Juju unit.
-
-    :param unit: The unit name (i.e: ceph-osd/0)
-    :type unit: str
-
-    :param label: The storage label (i.e: osd-devices)
-    :type label: str
-
-    :param pool: The pool on which to allocate the storage (i.e: cinder)
-    :type pool: str
-
-    :size: The size in GB of the storage to attach.
-    :type size: int
-
-    :returns: The name of the allocated storage.
-    """
-    rv = subprocess.check_output(['juju', 'add-storage', unit,
-                                  '{}={},{}'.format(label, pool,
-                                                    str(size) + 'GB')],
-                                 stderr=subprocess.STDOUT)
-    return rv.decode('UTF-8').replace('added storage ', '').split(' ')[0]
-
-
-def detach_storage(storage_name):
-    """Detach previously allocated Juju storage."""
-    subprocess.check_call(['juju', 'detach-storage', storage_name])
-
-
-def remove_storage(storage_name, force=False):
-    """Remove Juju storage.
-
-    :param storage_name: The name of the previously allocated Juju storage.
-    :type storage_name: str
-
-    :param force: If False (default), require that the storage be detached
-                  before it can be removed.
-    :type force: bool
-    """
-    cmd = ['juju', 'remove-storage', storage_name]
-    if force:
-        cmd.append('--force')
-    subprocess.check_call(cmd)
-
-
-def add_loop_device(unit, size=10):
-    """Add a loopback device to a Juju unit.
-
-    :param unit: The unit name on which to create the device.
-    :type unit: str
-
-    :param size: The size in GB of the device.
-    :type size: int
-
-    :returns: The device name.
-    """
-    loop_name = '/home/ubuntu/loop.img'
-    truncate = 'truncate --size {}GB {}'.format(size, loop_name)
-    losetup = 'losetup --find {}'.format(loop_name)
-    lofind = 'losetup -a | grep {} | cut -f1 -d ":"'.format(loop_name)
-    cmd = "sudo sh -c '{} && {} && {}'".format(truncate, losetup, lofind)
-    return zaza_model.run_on_unit(unit, cmd)
-
-
 class CephLowLevelTest(test_utils.OpenStackBaseTest):
     """Ceph Low Level Test Class."""
 
@@ -615,8 +551,8 @@ class CephTest(test_utils.OpenStackBaseTest):
         logging.info('Running add-disk action with a caching device')
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]
         for unit in osds:
-            add_storage(unit, 'cache-devices', 'cinder', 10)
-            loop_dev = add_loop_device(unit, 10)
+            juju_utils.add_storage(unit, 'cache-devices', 'cinder', 10)
+            loop_dev = juju_utils.add_loop_device(unit, 10)
             action_obj = zaza_model.run_action(
                 unit_name=unit,
                 action_name='add-disk',

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -557,8 +557,8 @@ class CephTest(test_utils.OpenStackBaseTest):
         mon = next(iter(zaza_model.get_units('ceph-mon'))).entity_id
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]
         for unit in osds:
-            add_storage(unit, 'cache-devices', 'cinder', 10)
-            loop_dev = add_loop_device(unit, 10)
+            zaza_model.add_storage(unit, 'cache-devices', 'cinder', 10)
+            loop_dev = zaza_utils.add_loop_device(unit, 10)
             action_obj = zaza_model.run_action(
                 unit_name=unit,
                 action_name='add-disk',

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -35,7 +35,6 @@ import zaza.openstack.utilities.exceptions as zaza_exceptions
 import zaza.openstack.utilities.generic as zaza_utils
 import zaza.utilities.juju as juju_utils
 import zaza.openstack.utilities.openstack as zaza_openstack
-import zaza.openstack.utilities.juju as zaza_juju
 
 
 class CephLowLevelTest(test_utils.OpenStackBaseTest):
@@ -558,8 +557,8 @@ class CephTest(test_utils.OpenStackBaseTest):
         osds = [x.entity_id for x in zaza_model.get_units('ceph-osd')]
         num_osds = self.get_num_osds(osds[0])
         for unit in osds:
-            zaza_juju.add_storage(unit, 'cache-devices', 'cinder', 10)
-            loop_dev = zaza_juju.add_loop_device(unit, 10)
+            zaza_model.add_storage(unit, 'cache-devices', 'cinder', 10)
+            loop_dev = zaza_utils.add_loop_device(unit, 10)
             action_obj = zaza_model.run_action(
                 unit_name=unit,
                 action_name='add-disk',

--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -723,3 +723,22 @@ def get_leaders_and_non_leaders(application_name):
         else:
             non_leaders.append(unit)
     return leader, non_leaders
+
+
+def add_loop_device(unit, size=10):
+    """Add a loopback device to a Juju unit.
+
+    :param unit: The unit name on which to create the device.
+    :type unit: str
+
+    :param size: The size in GB of the device.
+    :type size: int
+
+    :returns: The device name.
+    """
+    loop_name = '/home/ubuntu/loop.img'
+    truncate = 'truncate --size {}GB {}'.format(size, loop_name)
+    losetup = 'losetup --find {}'.format(loop_name)
+    lofind = 'losetup -a | grep {} | cut -f1 -d ":"'.format(loop_name)
+    cmd = "sudo sh -c '{} && {} && {}'".format(truncate, losetup, lofind)
+    return model.run_on_unit(unit, cmd)

--- a/zaza/openstack/utilities/juju.py
+++ b/zaza/openstack/utilities/juju.py
@@ -17,7 +17,9 @@
 
 import logging
 import functools
+import subprocess
 
+import zaza.model
 import zaza.utilities.juju
 
 
@@ -310,3 +312,67 @@ def get_subordinate_units(unit_list, charm_name=None, status=None,
         charm_name=charm_name,
         status=status,
         model_name=model_name)
+
+
+def add_storage(unit, label, pool, size):
+    """Add storage to a Juju unit.
+
+    :param unit: The unit name (i.e: ceph-osd/0)
+    :type unit: str
+
+    :param label: The storage label (i.e: osd-devices)
+    :type label: str
+
+    :param pool: The pool on which to allocate the storage (i.e: cinder)
+    :type pool: str
+
+    :size: The size in GB of the storage to attach.
+    :type size: int
+
+    :returns: The name of the allocated storage.
+    """
+    rv = subprocess.check_output(['juju', 'add-storage', unit,
+                                  '{}={},{}'.format(label, pool,
+                                                    str(size) + 'GB')],
+                                 stderr=subprocess.STDOUT)
+    return rv.decode('UTF-8').replace('added storage ', '').split(' ')[0]
+
+
+def detach_storage(storage_name):
+    """Detach previously allocated Juju storage."""
+    subprocess.check_call(['juju', 'detach-storage', storage_name])
+
+
+def remove_storage(storage_name, force=False):
+    """Remove Juju storage.
+
+    :param storage_name: The name of the previously allocated Juju storage.
+    :type storage_name: str
+
+    :param force: If False (default), require that the storage be detached
+                  before it can be removed.
+    :type force: bool
+    """
+    cmd = ['juju', 'remove-storage', storage_name]
+    if force:
+        cmd.append('--force')
+    subprocess.check_call(cmd)
+
+
+def add_loop_device(unit, size=10):
+    """Add a loopback device to a Juju unit.
+
+    :param unit: The unit name on which to create the device.
+    :type unit: str
+
+    :param size: The size in GB of the device.
+    :type size: int
+
+    :returns: The device name.
+    """
+    loop_name = '/home/ubuntu/loop.img'
+    truncate = 'truncate --size {}GB {}'.format(size, loop_name)
+    losetup = 'losetup --find {}'.format(loop_name)
+    lofind = 'losetup -a | grep {} | cut -f1 -d ":"'.format(loop_name)
+    cmd = "sudo sh -c '{} && {} && {}'".format(truncate, losetup, lofind)
+    return zaza.model.run_on_unit(unit, cmd)


### PR DESCRIPTION
This PR tests that a new device is succesfully added to the OSD charm, and that it's done so via the 'bcache' mechanism. The backing storage is provided via a loopback device, whereas the caching storage is provided by Juju itself.

NOTE: This PR now depends on this one for zaza: https://github.com/openstack-charmers/zaza/pull/479