### PR TITLE
Remove deprecation warnings

### DIFF
--- a/zaza/openstack/charm_tests/neutron/setup.py
+++ b/zaza/openstack/charm_tests/neutron/setup.py
@@ -23,9 +23,10 @@ from zaza.openstack.configure import (
 from zaza.openstack.utilities import (
     cli as cli_utils,
     generic as generic_utils,
-    juju as juju_utils,
     openstack as openstack_utils,
 )
+
+import zaza.utilities.juju as juju_utils
 
 import zaza.charm_lifecycle.utils as lifecycle_utils
 

--- a/zaza/openstack/configure/network.py
+++ b/zaza/openstack/configure/network.py
@@ -85,9 +85,10 @@ import sys
 from zaza.openstack.utilities import (
     cli as cli_utils,
     generic as generic_utils,
-    juju as juju_utils,
     openstack as openstack_utils,
 )
+
+import zaza.utilities.juju as juju_utils
 
 
 def setup_sdn(network_config, keystone_session=None):

--- a/zaza/openstack/utilities/openstack_upgrade.py
+++ b/zaza/openstack/utilities/openstack_upgrade.py
@@ -17,7 +17,7 @@
 This module contains a number of functions for upgrading OpenStack.
 """
 import logging
-import zaza.openstack.utilities.juju as juju_utils
+import zaza.utilities.juju as juju_utils
 
 import zaza.model
 from zaza import sync_wrapper


### PR DESCRIPTION
`zaza.openstack.utilities.juju` is deprecated in favour of `zaza.utilities.juju`.

Validated by running the [openstack-upgrade tests](https://github.com/openstack-charmers/charmed-openstack-tester/blob/master/tox.ini#L90).