### PR TITLE
Add glance tests for Cinder Storage backend

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -345,6 +345,20 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
             openstack_utils.get_images_by_name(glance_client, 'frank'),
             [])
 
+    def test_get_volumes_by_name(self):
+        volume_mock1 = mock.MagicMock()
+        volume_mock1.name = 'bob'
+        volume_mock2 = mock.MagicMock()
+        volume_mock2.name = 'bill'
+        cinder_client = mock.MagicMock()
+        cinder_client.volumes.list.return_value = [volume_mock1, volume_mock2]
+        self.assertEqual(
+            openstack_utils.get_volumes_by_name(cinder_client, 'bob'),
+            [volume_mock1])
+        self.assertEqual(
+            openstack_utils.get_volumes_by_name(cinder_client, 'frank'),
+            [])
+
     def test_find_cirros_image(self):
         urllib_opener_mock = mock.MagicMock()
         self.patch_object(openstack_utils, "get_urllib_opener")

--- a/zaza/openstack/charm_tests/glance/tests.py
+++ b/zaza/openstack/charm_tests/glance/tests.py
@@ -17,6 +17,7 @@
 """Encapsulate glance testing."""
 
 import logging
+import math
 
 import boto3
 import zaza.model as model
@@ -221,4 +222,47 @@ class GlanceExternalS3Test(test_utils.OpenStackBaseTest):
             "{}".format(image["size"], response["ContentLength"])
         )
         self.assertEqual(image["size"], response["ContentLength"])
+        openstack_utils.delete_image(self.glance_client, image["id"])
+
+
+class GlanceCinderBackendTest(test_utils.OpenStackBaseTest):
+    """Encapsulate glance tests using cinder backend."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Run class setup for running glance tests with cinder backend."""
+        super(GlanceCinderBackendTest, cls).setUpClass()
+        cls.glance_client = openstack_utils.get_glance_session_client(
+            cls.keystone_session)
+        cls.cinder_client = openstack_utils.get_cinder_session_client(
+            cls.keystone_session)
+
+    def test_100_create_delete_image(self):
+        """Create an image and do a simple validation of it.
+
+        Validate the size of the image in both Glance API and Cinder API.
+        """
+        image_name = "zaza-cinder-test-image"
+        openstack_utils.create_image(
+            glance=self.glance_client,
+            image_url=openstack_utils.find_cirros_image(arch="x86_64"),
+            image_name=image_name,
+            backend="cinder",
+        )
+        images = openstack_utils.get_images_by_name(
+            self.glance_client, image_name)
+        self.assertEqual(len(images), 1)
+        image = images[0]
+
+        volume_name = 'image-'+image["id"]
+        volumes = openstack_utils.get_volumes_by_name(
+            self.cinder_client, volume_name)
+        self.assertEqual(len(volumes), 1)
+        volume = volumes[0]
+
+        logging.info(
+            "Checking glance image size {} matches volume size {} "
+            "GB".format(image["size"], volume.size))
+        image_size_in_gb = int(math.ceil(float(image["size"]) / 1024 ** 3))
+        self.assertEqual(image_size_in_gb, volume.size)
         openstack_utils.delete_image(self.glance_client, image["id"])

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2225,6 +2225,19 @@ def get_images_by_name(glance, image_name):
     return [i for i in glance.images.list() if image_name == i.name]
 
 
+def get_volumes_by_name(cinder, volume_name):
+    """Get all cinder volume objects with the given name.
+
+    :param cinder: Authenticated cinderclient
+    :type cinder: cinderclient.Client
+    :param image_name: Name of volume
+    :type image_name: str
+    :returns: List of cinder volumes
+    :rtype: List[cinderclient.v3.volume, ...]
+    """
+    return [i for i in cinder.volumes.list() if volume_name == i.name]
+
+
 def find_cirros_image(arch):
     """Return the url for the latest cirros image for the given architecture.
 


### PR DESCRIPTION
Add zaza tests for charm glance when cinder is configured
as storage backend.

Related-Bug: LP#1905042