### PR TITLE
Use full binary paths for neutron test_901_pause_resume

### DIFF
--- a/zaza/openstack/charm_tests/neutron/tests.py
+++ b/zaza/openstack/charm_tests/neutron/tests.py
@@ -492,14 +492,11 @@ class NeutronApiTest(NeutronCreateNetworkTest):
         Pause service and check services are stopped then resume and check
         they are started
         """
-        bionic_stein = openstack_utils.get_os_release('bionic_stein')
-        if openstack_utils.get_os_release() >= bionic_stein:
-            pgrep_full = True
-        else:
-            pgrep_full = False
         with self.pause_resume(
-                ["neutron-server", "apache2", "haproxy"],
-                pgrep_full=pgrep_full):
+                ["/usr/bin/neutron-server",
+                 "/usr/sbin/apache2",
+                 "/usr/sbin/haproxy"],
+                pgrep_full=True):
             logging.info("Testing pause resume")
 
 


### PR DESCRIPTION
When pgrep_full=True is used, the resulting pgrep can match
more binaries than expected if the search pattern isn't specific
enough. This change makes the search patterns more specific
in order to only match the expected binaries.

Closes-Bug: #1933338