### PR TITLE
Switch unit.public_address to unit.get_public_address()

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -974,12 +974,15 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
     def test_get_keystone_ip__from_unit(self):
         self.patch_object(openstack_utils, "get_application_config_option")
         self.patch_object(openstack_utils.model, "get_units")
-        unit1 = mock.Mock(public_address='5.6.7.8')
+        self.patch_object(openstack_utils.model, 'get_unit_public_address')
+        mock_unit1 = mock.Mock()
+        self.get_unit_public_address.return_value = '5.6.7.8'
         self.get_application_config_option.return_value = None
-        self.get_units.return_value = [unit1]
+        self.get_units.return_value = [mock_unit1]
 
         self.assertEqual(openstack_utils.get_keystone_ip(), '5.6.7.8')
         self.get_units.assert_called_once_with('keystone', model_name=None)
+        self.get_unit_public_address.assert_called_once_with(mock_unit1)
 
     def test_get_keystone_api_version(self):
         self.patch_object(openstack_utils, "get_current_os_versions")

--- a/unit_tests/utilities/test_zaza_utilities_swift.py
+++ b/unit_tests/utilities/test_zaza_utilities_swift.py
@@ -91,12 +91,21 @@ class TestSwiftUtils(ut_utils.BaseTestCase):
         self.patch_object(juju_utils, 'get_full_juju_status')
         self.patch_object(zaza.model, 'get_application_config')
         self.patch_object(zaza.model, 'get_units')
+        self.patch_object(zaza.model, 'get_unit_public_address')
+
+        def _get_unit_public_address(u):
+            return u.public_address
+
+        self.get_unit_public_address.side_effect = _get_unit_public_address
+
         juju_status = mock.MagicMock()
         juju_status.applications = {}
         self.get_full_juju_status.return_value = juju_status
 
         for app_name, units in app_units.items():
-            expected_topology[units[0].public_address]['unit'] = units[0]
+            # ip = zaza.model.get_unit_public_address(units[0])
+            ip = units[0].public_address
+            expected_topology[ip]['unit'] = units[0]
 
         app_config = {}
         for app_name in app_units.keys():

--- a/unit_tests/utilities/test_zaza_utilities_swift.py
+++ b/unit_tests/utilities/test_zaza_utilities_swift.py
@@ -103,7 +103,6 @@ class TestSwiftUtils(ut_utils.BaseTestCase):
         self.get_full_juju_status.return_value = juju_status
 
         for app_name, units in app_units.items():
-            # ip = zaza.model.get_unit_public_address(units[0])
             ip = units[0].public_address
             expected_topology[ip]['unit'] = units[0]
 

--- a/zaza/openstack/charm_tests/ceph/dashboard/setup.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/setup.py
@@ -48,4 +48,5 @@ def set_grafana_url(model_name=None):
         'ceph-dashboard',
         {
             'grafana-api-url': "https://{}:3000".format(
-                unit.public_address)})
+                zaza.model.get_unit_public_address(unit))
+        })

--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -103,11 +103,13 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         units = zaza.model.get_units(self.application_name)
         for unit in units:
             r = self._run_request_get(
-                'https://{}:8443'.format(unit.public_address),
+                'https://{}:8443'.format(
+                    zaza.model.get_unit_public_address(unit)),
                 verify=self.local_ca_cert,
                 allow_redirects=False)
             if r.status_code == requests.codes.ok:
-                return 'https://{}:8443'.format(unit.public_address)
+                return 'https://{}:8443'.format(
+                    zaza.model.get_unit_public_address(unit))
 
     def test_dashboard_units(self):
         """Check dashboard units are configured correctly."""
@@ -116,10 +118,11 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         rcs = collections.defaultdict(list)
         for unit in units:
             r = self._run_request_get(
-                'https://{}:8443'.format(unit.public_address),
+                'https://{}:8443'.format(
+                    zaza.model.get_unit_public_address(unit)),
                 verify=verify,
                 allow_redirects=False)
-            rcs[r.status_code].append(unit.public_address)
+            rcs[r.status_code].append(zaza.model.get_unit_public_address(unit))
         self.assertEqual(len(rcs[requests.codes.ok]), 1)
         self.assertEqual(len(rcs[requests.codes.see_other]), len(units) - 1)
 

--- a/zaza/openstack/charm_tests/ceph/iscsi/tests.py
+++ b/zaza/openstack/charm_tests/ceph/iscsi/tests.py
@@ -79,7 +79,7 @@ class CephISCSIGatewayTest(test_utils.BaseCharmTest):
         ctxt['gateway_units'] = [
             {
                 'entity_id': u.entity_id,
-                'ip': u.public_address,
+                'ip': zaza.model.get_unit_public_address(u),
                 'hostname': host_names[u.entity_id]}
             for u in zaza.model.get_units('ceph-iscsi')]
         ctxt['gw_ip'] = sorted([g['ip'] for g in ctxt['gateway_units']])[0]

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -123,7 +123,7 @@ class CephRelationTest(test_utils.OpenStackBaseTest):
         remote_unit_name = 'ceph-mon/0'
         relation_name = 'osd'
         remote_unit = zaza_model.get_unit_from_name(remote_unit_name)
-        remote_ip = remote_unit.public_address
+        remote_ip = zaza_model.get_unit_public_address(remote_unit)
         relation = juju_utils.get_relation_from_unit(
             unit_name,
             remote_unit_name,
@@ -144,7 +144,7 @@ class CephRelationTest(test_utils.OpenStackBaseTest):
         unit_name = 'ceph-osd/0'
         relation_name = 'osd'
         remote_unit = zaza_model.get_unit_from_name(remote_unit_name)
-        remote_ip = remote_unit.public_address
+        remote_ip = zaza_model.get_unit_public_address(remote_unit)
         cmd = 'leader-get fsid'
         result = zaza_model.run_on_unit(remote_unit_name, cmd)
         fsid = result.get('Stdout').strip()
@@ -806,7 +806,9 @@ class CephPrometheusTest(unittest.TestCase):
         unit = zaza_model.get_unit_from_name(
             zaza_model.get_lead_unit_name('prometheus2'))
         self.assertEqual(
-            '3', _get_mon_count_from_prometheus(unit.public_address))
+            '3',
+            _get_mon_count_from_prometheus(
+                zaza_model.get_unit_public_address(unit)))
 
 
 class CephPoolConfig(Exception):

--- a/zaza/openstack/charm_tests/mysql/tests.py
+++ b/zaza/openstack/charm_tests/mysql/tests.py
@@ -90,7 +90,7 @@ class MySQLBaseTest(test_utils.OpenStackBaseTest):
             _primary_ip = _primary_ip.split(':')[0]
         units = zaza.model.get_units(self.application_name)
         for unit in units:
-            if _primary_ip in unit.public_address:
+            if _primary_ip in zaza.model.get_unit_public_address(unit):
                 return unit
 
     def get_blocked_mysql_routers(self):
@@ -821,12 +821,12 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
 
         logging.info(
             "Removing old unit from cluster: {} "
-            .format(leader_unit.public_address))
+            .format(zaza.model.get_unit_public_address(leader_unit)))
         action = zaza.model.run_action(
             nons[0],
             "remove-instance",
             action_params={
-                "address": leader_unit.public_address,
+                "address": zaza.model.get_unit_public_address(leader_unit),
                 "force": True})
         assert action.data.get("results") is not None, (
             "Remove instance action failed: No results: {}"
@@ -897,12 +897,12 @@ class MySQLInnoDBClusterScaleTest(MySQLBaseTest):
 
         logging.info(
             "Removing old unit from cluster: {} "
-            .format(non_leader_unit.public_address))
+            .format(zaza.model.get_unit_public_address(non_leader_unit)))
         action = zaza.model.run_action(
             leader,
             "remove-instance",
             action_params={
-                "address": non_leader_unit.public_address,
+                "address": zaza.model.get_unit_public_address(non_leader_unit),
                 "force": True})
         assert action.data.get("results") is not None, (
             "Remove instance action failed: No results: {}"
@@ -925,7 +925,7 @@ class MySQLInnoDBClusterPartitionTest(MySQLBaseTest):
         no_of_units = len(mysql_units)
         for index, unit in enumerate(mysql_units):
             next_unit = mysql_units[(index+1) % no_of_units]
-            ip_address = next_unit.public_address
+            ip_address = zaza.model.get_unit_public_address(next_unit)
             cmd = "sudo iptables -A INPUT -s {} -j DROP".format(ip_address)
             zaza.model.async_run_on_unit(unit, cmd)
 
@@ -949,7 +949,7 @@ class MySQLInnoDBClusterPartitionTest(MySQLBaseTest):
             leader_unit.entity_id,
             "force-quorum-using-partition-of",
             action_params={
-                "address": leader_unit.public_address,
+                "address": zaza.model.get_unit_public_address(leader_unit),
                 'i-really-mean-it': True
             })
 

--- a/zaza/openstack/charm_tests/neutron_arista/utils.py
+++ b/zaza/openstack/charm_tests/neutron_arista/utils.py
@@ -25,7 +25,8 @@ PLUGIN_APP_NAME = 'neutron-api-plugin-arista'
 
 def fixture_ip_addr():
     """Return the public IP address of the Arista test fixture."""
-    return zaza.model.get_units(FIXTURE_APP_NAME)[0].public_address
+    return zaza.model.get_unit_public_address(
+        zaza.model.get_units(FIXTURE_APP_NAME)[0])
 
 
 _FIXTURE_LOGIN = 'admin'

--- a/zaza/openstack/charm_tests/nova/tests.py
+++ b/zaza/openstack/charm_tests/nova/tests.py
@@ -461,7 +461,7 @@ class NovaCloudControllerActionTest(test_utils.OpenStackBaseTest):
                 if juju_az:
                     zone = juju_az
 
-            juju_units_az_map[unit.public_address] = zone
+            juju_units_az_map[zaza.model.get_unit_public_address(unit)] = zone
             continue
 
         session = openstack_utils.get_overcloud_keystone_session()

--- a/zaza/openstack/charm_tests/rabbitmq_server/tests.py
+++ b/zaza/openstack/charm_tests/rabbitmq_server/tests.py
@@ -120,7 +120,7 @@ class RmqTests(test_utils.OpenStackBaseTest):
 
         for dest_unit in units:
             dest_unit_name = dest_unit.entity_id
-            dest_unit_host = dest_unit.public_address
+            dest_unit_host = zaza.model.get_unit_public_address(dest_unit)
             dest_unit_host_name = host_names[dest_unit_name]
 
             for check_unit in units:
@@ -128,7 +128,8 @@ class RmqTests(test_utils.OpenStackBaseTest):
                 if dest_unit_name == check_unit_name:
                     logging.info("Skipping check for this unit to itself.")
                     continue
-                check_unit_host = check_unit.public_address
+                check_unit_host = zaza.model.get_unit_public_address(
+                    check_unit)
                 check_unit_host_name = host_names[check_unit_name]
 
                 amqp_msg_stamp = self._get_uuid_epoch_stamp()

--- a/zaza/openstack/charm_tests/rabbitmq_server/utils.py
+++ b/zaza/openstack/charm_tests/rabbitmq_server/utils.py
@@ -351,7 +351,7 @@ def configure_ssl_off(units, model_name=None, max_wait=60):
 
 def is_ssl_enabled_on_unit(unit, port=None):
     """Check a single juju rmq unit for ssl and port in the config file."""
-    host = unit.public_address
+    host = zaza.model.get_unit_public_address(unit)
     unit_name = unit.entity_id
 
     conf_file = '/etc/rabbitmq/rabbitmq.conf'
@@ -406,7 +406,7 @@ def connect_amqp_by_unit(unit, ssl=False,
     :param password: amqp user password
     :returns: pika amqp connection pointer or None if failed and non-fatal
     """
-    host = unit.public_address
+    host = zaza.model.get_unit_public_address(unit)
     unit_name = unit.entity_id
 
     if ssl:

--- a/zaza/openstack/charm_tests/saml_mellon/setup.py
+++ b/zaza/openstack/charm_tests/saml_mellon/setup.py
@@ -228,7 +228,7 @@ def keystone_federation_setup_idp1():
     """Configure Keystone Federation for the local IdP #1."""
     test_saml_idp_unit = zaza.model.get_units("test-saml-idp1")[0]
     idp_remote_id = LOCAL_IDP_REMOTE_ID.format(
-        test_saml_idp_unit.public_address)
+        zaza.model.get_unit_public_address(test_saml_idp_unit))
 
     keystone_federation_setup(
         federated_domain="federated_domain_idp1",
@@ -241,7 +241,7 @@ def keystone_federation_setup_idp2():
     """Configure Keystone Federation for the local IdP #2."""
     test_saml_idp_unit = zaza.model.get_units("test-saml-idp2")[0]
     idp_remote_id = LOCAL_IDP_REMOTE_ID.format(
-        test_saml_idp_unit.public_address)
+        zaza.model.get_unit_public_address(test_saml_idp_unit))
 
     keystone_federation_setup(
         federated_domain="federated_domain_idp2",

--- a/zaza/openstack/charm_tests/saml_mellon/tests.py
+++ b/zaza/openstack/charm_tests/saml_mellon/tests.py
@@ -54,7 +54,7 @@ class CharmKeystoneSAMLMellonTest(BaseKeystoneTest):
         if self.vip:
             ip = self.vip
         else:
-            ip = unit.public_address
+            ip = zaza.model.get_unit_public_address(unit)
 
         action = zaza.model.run_action(unit.entity_id, self.action)
         if "failed" in action.data["status"]:
@@ -81,7 +81,7 @@ class CharmKeystoneSAMLMellonTest(BaseKeystoneTest):
             keystone_ip = self.vip
         else:
             unit = zaza.model.get_units(self.application_name)[0]
-            keystone_ip = unit.public_address
+            keystone_ip = zaza.model.get_unit_public_address(unit)
 
         horizon = "openstack-dashboard"
         horizon_vip = (zaza.model.get_application_config(horizon)
@@ -90,7 +90,7 @@ class CharmKeystoneSAMLMellonTest(BaseKeystoneTest):
             horizon_ip = horizon_vip
         else:
             unit = zaza.model.get_units("openstack-dashboard")[0]
-            horizon_ip = unit.public_address
+            horizon_ip = zaza.model.get_unit_public_address(unit)
 
         if self.tls_rid:
             proto = "https"
@@ -258,7 +258,7 @@ class BaseCharmKeystoneSAMLMellonTest(BaseKeystoneTest):
     def test_run_get_sp_metadata_action(self):
         """Validate the get-sp-metadata action."""
         unit = zaza.model.get_units(self.application_name)[0]
-        ip = self.vip if self.vip else unit.public_address
+        ip = self.vip if self.vip else zaza.model.get_unit_public_address(unit)
 
         action = zaza.model.run_action(unit.entity_id, self.action)
         self.assertNotIn(
@@ -283,14 +283,16 @@ class BaseCharmKeystoneSAMLMellonTest(BaseKeystoneTest):
     def test_saml_mellon_redirects(self):
         """Validate the horizon -> keystone -> IDP redirects."""
         unit = zaza.model.get_units(self.application_name)[0]
-        keystone_ip = self.vip if self.vip else unit.public_address
+        keystone_ip = self.vip if self.vip else (
+            zaza.model.get_unit_public_address(unit))
 
         horizon = "openstack-dashboard"
         horizon_config = zaza.model.get_application_config(horizon)
         horizon_vip = horizon_config.get("vip").get("value")
         unit = zaza.model.get_units("openstack-dashboard")[0]
 
-        horizon_ip = horizon_vip if horizon_vip else unit.public_address
+        horizon_ip = horizon_vip if horizon_vip else (
+            zaza.model.get_unit_public_address(unit))
         proto = "https" if self.tls_rid else "http"
 
         # Use Keystone URL for < Focal
@@ -299,8 +301,8 @@ class BaseCharmKeystoneSAMLMellonTest(BaseKeystoneTest):
         else:
             region = "default"
 
-        idp_address = zaza.model.get_units(
-            self.test_saml_idp_app_name)[0].public_address
+        idp_address = zaza.model.get_unit_public_address(
+            zaza.model.get_units(self.test_saml_idp_app_name)[0])
 
         horizon_url = "{}://{}/horizon/auth/login/".format(proto, horizon_ip)
         horizon_expect = '<option value="{0}">{1}</option>'.format(

--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -622,7 +622,7 @@ def port_knock_units(units, port=22, expect_success=True):
     :returns: None if successful, Failure message otherwise
     """
     for u in units:
-        host = u.public_address
+        host = model.get_unit_public_address(u)
         connected = is_port_open(port, host)
         if not connected and expect_success:
             return 'Socket connect failed.'

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1554,7 +1554,7 @@ def create_bgp_peer(neutron_client, peer_application_name='quagga',
     :rtype: dict
     """
     peer_unit = model.get_units(peer_application_name)[0]
-    peer_ip = peer_unit.public_address
+    peer_ip = model.get_unit_public_address(peer_unit)
     bgp_peers = neutron_client.list_bgp_peers(name=peer_application_name)
     if len(bgp_peers['bgp_peers']) == 0:
         logging.info('Creating BGP Peer')
@@ -2035,7 +2035,7 @@ def get_keystone_ip(model_name=None):
         # strip the option, splits on whitespace and return the first one.
         return vip_option.strip().split()[0]
     unit = model.get_units('keystone', model_name=model_name)[0]
-    return unit.public_address
+    return model.get_unit_public_address(unit)
 
 
 def get_keystone_api_version(model_name=None):

--- a/zaza/openstack/utilities/swift.py
+++ b/zaza/openstack/utilities/swift.py
@@ -207,7 +207,7 @@ def get_swift_storage_topology(model_name=None):
             region = app_config['storage-region']['value']
             zone = app_config['zone']['value']
             for unit in zaza.model.get_units(app_name, model_name=model_name):
-                topology[unit.public_address] = {
+                topology[zaza.model.get_unit_public_address(unit)] = {
                     'app_name': app_name,
                     'unit': unit,
                     'region': region,


### PR DESCRIPTION
Due to the bug [1] on OpenStack providers, unit.public_address doesn't
actually work reliably.  The fix [2] is only for the async function
unit.get_public_address().  Sadly, zaza relied on unit.public_address
and so it needs this patch for juju 2.9 support on OpenStack providers.

This patch relies on an associated patch in zaza [3]; thus this will
fails its tests until that passes.

[1]: https://github.com/juju/python-libjuju/issues/551
[2]: https://github.com/juju/python-libjuju/pull/600
[3]: https://github.com/openstack-charmers/zaza/pull/468