### PR TITLE
Enable get_keystone_ip() to work with multiple vips config

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -956,6 +956,31 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.assertEqual(expected, result)
         self._get_os_rel_pair.assert_called_once_with(application='myapp')
 
+    def test_get_keystone_ip__vip(self):
+        self.patch_object(openstack_utils, "get_application_config_option")
+        self.patch_object(openstack_utils.model, "get_units")
+        unit1 = mock.Mock(public_address='5.6.7.8')
+        self.get_application_config_option.return_value = "1.2.3.4"
+        self.get_units.return_value = [unit1]
+
+        self.assertEqual(
+            openstack_utils.get_keystone_ip(model_name='some-model'),
+            '1.2.3.4')
+        self.get_application_config_option.assert_called_once_with(
+            'keystone', 'vip', model_name='some-model')
+        self.get_application_config_option.return_value = "    1.2.3.4    11"
+        self.assertEqual(openstack_utils.get_keystone_ip(), '1.2.3.4')
+
+    def test_get_keystone_ip__from_unit(self):
+        self.patch_object(openstack_utils, "get_application_config_option")
+        self.patch_object(openstack_utils.model, "get_units")
+        unit1 = mock.Mock(public_address='5.6.7.8')
+        self.get_application_config_option.return_value = None
+        self.get_units.return_value = [unit1]
+
+        self.assertEqual(openstack_utils.get_keystone_ip(), '5.6.7.8')
+        self.get_units.assert_called_once_with('keystone', model_name=None)
+
     def test_get_keystone_api_version(self):
         self.patch_object(openstack_utils, "get_current_os_versions")
         self.patch_object(openstack_utils, "get_application_config_option")

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2019,6 +2019,9 @@ def get_undercloud_auth():
 def get_keystone_ip(model_name=None):
     """Return the IP address to use when communicating with keystone api.
 
+    If there are multiple VIP addresses specified in the 'vip' option for the
+    keystone unit, then ONLY the first one is returned.
+
     :param model_name: Name of model to query.
     :type model_name: str
     :returns: IP address
@@ -2029,7 +2032,8 @@ def get_keystone_ip(model_name=None):
         'vip',
         model_name=model_name)
     if vip_option:
-        return vip_option
+        # strip the option, splits on whitespace and return the first one.
+        return vip_option.strip().split()[0]
     unit = model.get_units('keystone', model_name=model_name)[0]
     return unit.public_address
 


### PR DESCRIPTION
The keystone charm allows multiple VIP addresses to be configured via
the 'vip' config parameter.  Unfortunately, get_keystone_ip() didn't
support this.  This patch adds that support, plus the missing tests.

Closes: #689