### PR TITLE
add glance-simplestreams-syns to openstack upgrade exclude list

### DIFF
--- a/zaza/openstack/utilities/upgrade_utils.py
+++ b/zaza/openstack/utilities/upgrade_utils.py
@@ -49,7 +49,7 @@ SERVICE_GROUPS = (
         'nova-compute', 'ceph-osd',
         'swift-proxy', 'swift-storage']))
 
-UPGRADE_EXCLUDE_LIST = ['rabbitmq-server', 'percona-cluster']
+UPGRADE_EXCLUDE_LIST = ['rabbitmq-server', 'percona-cluster', 'glance-simplestreams-sync']
 
 
 def get_upgrade_candidates(model_name=None, filters=None):

--- a/zaza/openstack/utilities/upgrade_utils.py
+++ b/zaza/openstack/utilities/upgrade_utils.py
@@ -49,7 +49,11 @@ SERVICE_GROUPS = (
         'nova-compute', 'ceph-osd',
         'swift-proxy', 'swift-storage']))
 
-UPGRADE_EXCLUDE_LIST = ['rabbitmq-server', 'percona-cluster', 'glance-simplestreams-sync']
+UPGRADE_EXCLUDE_LIST = [
+    'rabbitmq-server',
+    'percona-cluster',
+    'glance-simplestreams-sync',
+]
 
 
 def get_upgrade_candidates(model_name=None, filters=None):


### PR DESCRIPTION
glance-simplestreams-sync does have the `source` option, but this does not seem to point to the openstack version:

```
$ juju config glance-simplestreams-sync
...
  source:
    description: DEPRECATED - option no longer used and will be removed
    source: user
    type: string
    value: distro
...
```

The value here is set by me to avoid errors with the upgrade testing, but is normally left unset in sqa deployments.