### PR TITLE
Retry find_cirros_image() on URLError

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2242,6 +2242,9 @@ def get_volumes_by_name(cinder, volume_name):
     return [i for i in cinder.volumes.list() if volume_name == i.name]
 
 
+@tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, max=60),
+                reraise=True,
+                retry=tenacity.retry_if_exception_type(urllib.error.URLError))
 def find_cirros_image(arch):
     """Return the url for the latest cirros image for the given architecture.
 
@@ -2268,7 +2271,7 @@ def download_image(image_url, target_file):
 
     :param image_url: URL to download image from
     :type image_url: str
-    :param target_file: Local file to savee image to
+    :param target_file: Local file to save image to
     :type target_file: str
     """
     opener = get_urllib_opener()


### PR DESCRIPTION
There are situations where the DNS infrastructure hasn't been stable and
many CI jobs have failed with the error:

  urllib.error.URLError: <urlopen error [Errno -3] Temporary failure in name resolution>

This change decorates the function find_cirros_image() to retry and give
the job more chances of recovering from the DNS failures.