### PR TITLE
Import exceptions module instead of exception

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -29,7 +29,7 @@ import zaza.openstack.utilities.openstack as openstack_utils
 
 from zaza.openstack.utilities import generic as generic_utils
 from zaza.openstack.utilities import ObjectRetrierWraps
-from zaza.openstack.utilities.exception import (
+from zaza.openstack.utilities.exceptions import (
     LoadBalancerUnexpectedState,
     LoadBalancerUnrecoverableError,
 )


### PR DESCRIPTION
A missing 's' on importing the zaza.openstack.utilities.exceptions in
the octavia tests are causing gate tests to fail. This fixes the import
to point at the right module.

Fixes #721

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>