### PR TITLE
Fix Octavia wait_for_lb_resource()

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -302,8 +302,9 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         # retrying and delaying the failure.
         if resp['provisioning_status'] == 'ERROR':
             raise LoadBalancerUnrecoverableError(msg)
+        elif resp['provisioning_status'] != provisioning_status:
+            raise LoadBalancerUnexpectedState(msg)
 
-        assert resp['provisioning_status'] == provisioning_status, msg
         if operating_status:
             logging.info('Current operating status: {}, waiting for {}'
                          .format(resp['operating_status'], operating_status))


### PR DESCRIPTION
This change drops the use of AssertionError in favor of
LoadBalancerUnexpectedState that was introduced by commit acaeb62 which
stopped retrying on AssertionError.