### PR TITLE
Use snapshot_support=True for manila share type

### DIFF
--- a/zaza/openstack/charm_tests/manila_ganesha/setup.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/setup.py
@@ -42,5 +42,5 @@ def setup_ganesha_share_type(manila_client=None):
         extra_specs={
             'vendor_name': 'Ceph',
             'storage_protocol': 'NFS',
-            'snapshot_support': False,
+            'snapshot_support': True,
         })


### PR DESCRIPTION
The extra specs of a manila share type need to match the
share service's capabilities. [1]

[1] https://docs.openstack.org/manila/pike/admin/shared-file-systems-troubleshoot.html#id2

Closes-Bug: #1962204
(cherry picked from commit bf6b466b55e5a9602e5b75ba8e226cbe2dcb040e)