### PR TITLE
Fix netapp tests

### DIFF
--- a/zaza/openstack/charm_tests/cinder_backend/tests.py
+++ b/zaza/openstack/charm_tests/cinder_backend/tests.py
@@ -49,6 +49,16 @@ class CinderBackendTest(test_utils.OpenStackBaseTest):
             self.expected_config_content,
             timeout=2)
 
+    def check_volume_host(self, volume):
+        """Validate the volume id from the expected backend.
+
+        :param volume: Volume to check
+        :type volume: cinderclient.v3.volumes.Volume
+        """
+        self.assertEqual(
+            getattr(volume, 'os-vol-host-attr:host').split('#')[0],
+            'cinder@{}'.format(self.backend_name))
+
     def test_create_volume(self):
         """Test creating a volume with basic configuration."""
         test_vol_name = "zaza{}".format(uuid.uuid1().fields[0])
@@ -64,8 +74,6 @@ class CinderBackendTest(test_utils.OpenStackBaseTest):
                 expected_status='available',
                 msg='Volume status wait')
             test_vol = self.cinder_client.volumes.find(name=test_vol_name)
-            self.assertEqual(
-                getattr(test_vol, 'os-vol-host-attr:host').split('#')[0],
-                'cinder@{}'.format(self.backend_name))
+            self.check_volume_host(test_vol)
         finally:
             self.cinder_client.volumes.delete(vol_new)

--- a/zaza/openstack/charm_tests/cinder_netapp/tests.py
+++ b/zaza/openstack/charm_tests/cinder_netapp/tests.py
@@ -16,19 +16,33 @@
 
 """Encapsulate cinder-netapp testing."""
 
+import zaza.model
 from zaza.openstack.charm_tests.cinder_backend.tests import CinderBackendTest
 
 
 class CinderNetAppTest(CinderBackendTest):
     """Encapsulate netapp tests."""
 
-    backend_name = 'cinder-netapp'
-
-    expected_config_content = {
+    configs = zaza.model.get_application_config("cinder-netapp")
+    family = configs['netapp-storage-family']['value']
+    protocol = configs['netapp-storage-protocol']['value']
+    backend_name = configs['volume-backend-name']['value']
+    expected_contents = {
         'cinder-netapp': {
-            'netapp_storage_family': ['ontap_cluster'],
-            'netapp_storage_protocol': ['iscsi'],
-            'volume_backend_name': ['cinder_netapp'],
+            'netapp_storage_family': [family],
+            'netapp_storage_protocol': [protocol],
+            'volume_backend_name': [backend_name],
             'volume_driver':
                 ['cinder.volume.drivers.netapp.common.NetAppDriver'],
         }}
+
+    def check_volume_host(self, volume):
+        """Validate the volume id from the expected backend.
+
+        :param volume: Volume to check
+        :type volume: cinderclient.v3.volumes.Volume
+        """
+        host = getattr(volume, 'os-vol-host-attr:host')
+        self.assertEqual(
+            host.split('#')[0].split('@')[1],
+            'cinder-netapp')


### PR DESCRIPTION
* Check the charm config options when constructing the expected
  cinder.conf contents. This makes the tests less brittle when
  bundles are changed.

* Only check the volume backend name for netapp as the host part
  is now the cinder units hostname