### PR TITLE
Add test for ceph-dashboard SAML functionality

### DIFF
--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -226,8 +226,9 @@ class CephDashboardTest(test_utils.BaseCharmTest):
 
     def test_saml(self):
         """Check that the dashboard is accessible with SAML enabled."""
-        if (openstack_utils.get_os_release() <
-                openstack_utils.get_os_release('focal_yoga')):
+        get_os_release = openstack_utils.get_os_release
+        if (get_os_release(application='vault') <
+                get_os_release('focal_yoga', application='vault')):
             return
 
         url = self.get_master_dashboard_url()

--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -227,8 +227,8 @@ class CephDashboardTest(test_utils.BaseCharmTest):
     def test_saml(self):
         """Check that the dashboard is accessible with SAML enabled."""
         get_os_release = openstack_utils.get_os_release
-        if (get_os_release(application='vault') <
-                get_os_release('focal_yoga', application='vault')):
+        if (get_os_release(application='ceph-mon') <
+                get_os_release('focal_yoga')):
             return
 
         url = self.get_master_dashboard_url()

--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -243,4 +243,11 @@ class CephDashboardTest(test_utils.BaseCharmTest):
                     'saml-idp-metadata': 'file://{}'.format(tmp.name),
                 }
             )
-            self.access_dashboard(url)
+
+            # Login must be redirected.
+            resp = requests.get(url + '/auth/saml2/login')
+            self.assertTrue(resp.is_redirect)
+
+            # Check that metadata is present.
+            resp = requests.get(url + '/auth/saml2/metadata')
+            self.assertEqual(resp.status_code, requests.code.ok)


### PR DESCRIPTION
This PR adds a new test for the ceph-dashboard charm, which involves setting up some config parameters to enable SAML authentication and then testing that the dashboard is indeed accessible.