### PR TITLE
Add Ceph versions to OS_CODENAMES

### DIFF
--- a/zaza/openstack/utilities/os_versions.py
+++ b/zaza/openstack/utilities/os_versions.py
@@ -266,11 +266,13 @@ PACKAGE_CODENAMES = {
         ('11', 'victoria'),
     ]),
     'ceph-common': OrderedDict([
-        ('10', 'mitaka'),  # jewel
-        ('12', 'queens'),  # luminous
-        ('13', 'rocky'),   # mimic
-        ('14', 'train'),   # nautilus
-        ('15', 'ussuri'),  # octopus
+        ('10', 'mitaka'),    # jewel
+        ('12', 'queens'),    # luminous
+        ('13', 'rocky'),     # mimic
+        ('14', 'train'),     # nautilus
+        ('15', 'ussuri'),    # octopus
+        ('16', 'victoria'),  # pacific
+        ('17', 'yoga'),      # quincy
     ]),
     'placement-common': OrderedDict([
         ('2', 'train'),


### PR DESCRIPTION
There are some Ceph charms that do not install the
openstack-release package, so fall through to the
dict to identify which release they are on, and can
fail with a KeyError when not finding a matching
entry for Pacific and Quincy.