### PR TITLE
Setup loop devices early on in the Ceph tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -188,7 +188,6 @@ class CephTest(test_utils.OpenStackBaseTest):
         super(CephTest, cls).setUpClass()
         cls.loop_devs = {}   # Maps osd -> loop device
         for osd in (x.entity_id for x in zaza_model.get_units('ceph-osd')):
-            zaza_model.add_storage(osd, 'cache-devices', 'cinder', 10)
             loop_dev = zaza_utils.add_loop_device(osd, 10).get('Stdout')
             cls.loop_devs[osd] = loop_dev
 

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -595,6 +595,7 @@ class CephTest(test_utils.OpenStackBaseTest):
             results = json.loads(action_obj.data['results']['message'])
             results = results[next(iter(results))]
             self.assertEqual(results['osd-ids'], osd_id)
+            zaza_model.run_on_unit(param['unit'], 'partprobe')
         zaza_model.wait_for_application_states()
 
         logging.info('Recycling previously removed OSDs')


### PR DESCRIPTION
There appears to be a race condition between the loop device creation and its actual usage. In order to prevent that, this PR setups these devices during the test initialization instead of right before using them in the 'add-disk' tests.