### PR TITLE
Fix requirements for zaza on stable/yoga

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ paramiko
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
-git+https://github.com/openstack-charmers/zaza#egg=zaza
+git+https://github.com/openstack-charmers/zaza@stable/yoga#egg=zaza
 
 # Newer versions require a Rust compiler to build, see
 # * https://github.com/openstack-charmers/zaza/issues/421

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_require = [
     'python-ceilometerclient',
     'python-cinderclient<6.0.0',
     'python-swiftclient<3.9.0',
-    'zaza@git+https://github.com/openstack-charmers/zaza.git#egg=zaza',
+    'zaza@git+https://github.com/openstack-charmers/zaza.git@stable/yoga#egg=zaza',
 ]
 
 tests_require = [


### PR DESCRIPTION
zaza.openstack.tests requires zaza, but it should be the
stable/yoga version rather than the development tip.