### PR TITLE
Add test for ceph auth actions get-or-create-user and delete-user

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -635,7 +635,7 @@ class CephTest(test_utils.OpenStackBaseTest):
 
         self.assertEqual(get_results, create_results)
 
-        logging.info('Deleting user...')
+        logging.info('Deleting existing user...')
         action_obj = zaza_model.run_action_on_leader(
             'ceph-mon',
             'delete-user',
@@ -644,6 +644,16 @@ class CephTest(test_utils.OpenStackBaseTest):
         logging.debug('Result of action: {}'.format(action_obj))
         delete_results = action_obj.data['results']['message']
         self.assertEqual(delete_results, "updated\n")
+
+        logging.info('Deleting non-existing user...')
+        action_obj = zaza_model.run_action_on_leader(
+            'ceph-mon',
+            'delete-user',
+            action_params={'username': 'sandbox'}
+        )
+        logging.debug('Result of action: {}'.format(action_obj))
+        delete_results = action_obj.data['results']['message']
+        self.assertEqual(delete_results, "entity client.sandbox does not exist\n")
 
 
 class CephRGWTest(test_utils.OpenStackBaseTest):

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -653,7 +653,7 @@ class CephTest(test_utils.OpenStackBaseTest):
         )
         logging.debug('Result of action: {}'.format(action_obj))
         delete_results = action_obj.data['results']['message']
-        self.assertEqual(delete_results, 
+        self.assertEqual(delete_results,
                          "entity client.sandbox does not exist\n")
 
 

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -611,6 +611,40 @@ class CephTest(test_utils.OpenStackBaseTest):
         zaza_model.wait_for_application_states()
         self.assertEqual(len(osds) * 2, self.get_num_osds(mon))
 
+    def test_ceph_auth(self):
+        """Test creating and deleting user."""
+        logging.info('Creating user and exported keyring...')
+        action_obj = zaza_model.run_action_on_leader(
+            'ceph-mon',
+            'get-or-create-user',
+            action_params={'username': 'sandbox',
+                           'mon-caps': 'allow r',
+                           'osd-caps': 'allow r'}
+        )
+        logging.debug('Result of action: {}'.format(action_obj))
+        create_results = json.loads(action_obj.data['results']['message'])
+
+        logging.info('Getting existing user and exported keyring...')
+        action_obj = zaza_model.run_action_on_leader(
+            'ceph-mon',
+            'get-or-create-user',
+            action_params={'username': 'sandbox'}
+        )
+        logging.debug('Result of action: {}'.format(action_obj))
+        get_results = json.loads(action_obj.data['results']['message'])
+
+        self.assertEqual(get_results, create_results)
+
+        logging.info('Deleting user...')
+        action_obj = zaza_model.run_action_on_leader(
+            'ceph-mon',
+            'delete-user',
+            action_params={'username': 'sandbox'}
+        )
+        logging.debug('Result of action: {}'.format(action_obj))
+        delete_results = action_obj.data['results']['message']
+        self.assertEqual(delete_results, "updated\n")
+
 
 class CephRGWTest(test_utils.OpenStackBaseTest):
     """Ceph RADOS Gateway Daemons Test Class."""

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -653,7 +653,8 @@ class CephTest(test_utils.OpenStackBaseTest):
         )
         logging.debug('Result of action: {}'.format(action_obj))
         delete_results = action_obj.data['results']['message']
-        self.assertEqual(delete_results, "entity client.sandbox does not exist\n")
+        self.assertEqual(delete_results, 
+                         "entity client.sandbox does not exist\n")
 
 
 class CephRGWTest(test_utils.OpenStackBaseTest):


### PR DESCRIPTION
This PR adds functional tests for charm-ceph-mon actions added in the following review:
https://review.opendev.org/c/openstack/charm-ceph-mon/+/841500