### PR TITLE
Upgradeable tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -38,7 +38,7 @@ import zaza.openstack.utilities.openstack as zaza_openstack
 import zaza.openstack.utilities.generic as generic_utils
 
 
-class CephLowLevelTest(test_utils.OpenStackBaseTest):
+class CephLowLevelTest(test_utils.UpgradeableTest):
     """Ceph Low Level Test Class."""
 
     @classmethod
@@ -109,7 +109,7 @@ class CephLowLevelTest(test_utils.OpenStackBaseTest):
             self.assertEqual(pool['pg_autoscale_mode'], 'on')
 
 
-class CephRelationTest(test_utils.OpenStackBaseTest):
+class CephRelationTest(test_utils.UpgradeableTest):
     """Ceph's relations test class."""
 
     @classmethod
@@ -180,7 +180,7 @@ class CephRelationTest(test_utils.OpenStackBaseTest):
         self._ceph_to_ceph_osd_relation(remote_unit_name)
 
 
-class CephTest(test_utils.OpenStackBaseTest):
+class CephTest(test_utils.UpgradeableTest):
     """Ceph common functional tests."""
 
     @classmethod

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -1298,10 +1298,12 @@ class BaseDeferredRestartTest(BaseCharmTest):
 
 class UpgradeableTest(OpenStackBaseTest):
     """Base class for tests that test charm upgrades."""
+
     upgraded = False
 
     @classmethod
     def setUpClass(cls):
+        """Upgrade the needed charms before running the tests."""
         super(UpgradeableTest, cls).setUpClass()
         if cls.upgraded:
             return

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -1350,7 +1350,29 @@ def _patch_upgrade(method, cls):
 
 
 def lazy_upgrade(cls):
-    """Decorate class that needs to run upgradeable methods."""
+    """Decorate class that needs to run upgradeable methods.
+
+    This decorator is meant to be used in tandem with the 'upgradeable_test'
+    one. Specifically, this one decorates classes while the other one
+    decorates methods. So you can have a test class like:
+
+    @lazy_upgrade
+    class MyTestClass(BaseCharmTest):
+
+      def test_1(self):
+        pass
+
+      @upgradeable_test
+      def test_2(self):
+        pass
+
+    In this example, the test class has 2 methods, the second one being
+    an 'upgradeable' method; i.e: this method runs twice, the first pass
+    being a regular run, while the second one does so after upgrading the
+    charms specified in the tests.yaml file. This second pass is done from
+    a dynamically generated method, prefixed by 'test_999', to try to make
+    it run as late as possible.
+    """
     changes = []
     for name, method in cls.__dict__.items():
         if getattr(method, 'needs_upgrade', None):


### PR DESCRIPTION
This PR allows functional tests to specify a list of charms that should be upgraded (via the 'upgrade_charms' key in the tests.yaml file), which makes test subclasses of a new type to upgrade said charms before running the tests.
