### PR TITLE
Add new ceph-fs configuration test

### DIFF
--- a/zaza/openstack/charm_tests/ceph/fs/tests.py
+++ b/zaza/openstack/charm_tests/ceph/fs/tests.py
@@ -124,7 +124,6 @@ write_files:
                 cmd = "sudo ceph daemon mds." \
                       "$HOSTNAME config show | grep {}".format(config)
                 conf = model.run_on_unit(self.TESTED_UNIT, cmd)
-                print(conf)
                 for i in (conf['Stdout'].replace('"', '')
                                         .replace(',', '')
                                         .strip()


### PR DESCRIPTION
This PR adds functional tests for the charm-ceph-fs config options added in the following review:
https://review.opendev.org/c/openstack/charm-ceph-fs/+/842555