### PR TITLE
Refresh kernel partition table between tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/iscsi/tests.py
+++ b/zaza/openstack/charm_tests/ceph/iscsi/tests.py
@@ -239,6 +239,7 @@ class CephISCSIGatewayTest(test_utils.BaseCharmTest):
                 'name': self.EC_METADATA_POOL}))
 
     def refresh_partitions(self, ctxt):
+        """Refresh kernel partition tables in client."""
         self.run_commands(ctxt['client_entity_id'], ('partprobe', ), ctxt)
 
     def run_client_checks(self, test_ctxt):

--- a/zaza/openstack/charm_tests/ceph/iscsi/tests.py
+++ b/zaza/openstack/charm_tests/ceph/iscsi/tests.py
@@ -238,6 +238,9 @@ class CephISCSIGatewayTest(test_utils.BaseCharmTest):
             action_params={
                 'name': self.EC_METADATA_POOL}))
 
+    def refresh_partitions(self, ctxt):
+        self.run_commands(ctxt['client_entity_id'], ('partprobe', ), ctxt)
+
     def run_client_checks(self, test_ctxt):
         """Check access to mulipath device.
 
@@ -254,6 +257,7 @@ class CephISCSIGatewayTest(test_utils.BaseCharmTest):
         self.logout_iscsi_targets(test_ctxt)
         self.login_iscsi_target(test_ctxt)
         self.check_client_device(test_ctxt, init_client=False)
+        self.refresh_partitions(test_ctxt)
 
     def test_create_and_mount_volume(self):
         """Test creating a target and mounting it on a client."""


### PR DESCRIPTION
The test suite for ceph-iscsi does a bunch of operations on filesystems in quick succession, so some tests are prone to fail if the kernel doesn't update the partition table. This PR does this manually between tests by calling the 'partprobe' command.