### PR TITLE
Trilio use guest_utils.launch_instance_retryer

### DIFF
--- a/zaza/openstack/charm_tests/trilio/tests.py
+++ b/zaza/openstack/charm_tests/trilio/tests.py
@@ -337,7 +337,7 @@ class TrilioBaseTest(test_utils.OpenStackBaseTest):
             name="{}-100-vol".format(self.RESOURCE_PREFIX),
         )
 
-        instance = guest_utils.launch_instance(
+        instance = guest_utils.launch_instance_retryer(
             glance_setup.CIRROS_IMAGE_NAME,
             vm_name="{}-server".format(self.RESOURCE_PREFIX),
         )


### PR DESCRIPTION
Switch Trilio tests to use the new launch_instance_retryer to
make the tests more resilant to issues creating and connecting
to a guest.