### PR TITLE
Change the ghost share path

### DIFF
--- a/zaza/openstack/charm_tests/trilio/tests.py
+++ b/zaza/openstack/charm_tests/trilio/tests.py
@@ -409,7 +409,7 @@ class TrilioGhostNFSShareTest(TrilioBaseTest):
             self.lead_unit,
             'ghost-share',
             action_params={
-                'nfs-shares': '10.20.0.1:/srv/testing'
+                'nfs-shares': '10.20.0.1:/srv/ghost-testing'
             },
             model_name=self.model_name)
         )


### PR DESCRIPTION
Trilio 4.2 generates a hash for the nfs share bases on the path
alone. Unfortunately the existing Trilio tests set the nfs share
and the ghost share to have the same path but different source
IPs. For previous Trilio releases this was fine as the share
hash was different but now they clash and the test fails because it
thinks the share is already mounted.