### PR TITLE
Don't test nrpe bits on rabbitmq-server.

### DIFF
--- a/zaza/openstack/charm_tests/rabbitmq_server/tests.py
+++ b/zaza/openstack/charm_tests/rabbitmq_server/tests.py
@@ -271,6 +271,13 @@ class RmqTests(test_utils.OpenStackBaseTest):
 
     def test_414_rmq_nrpe_monitors(self):
         """Check rabbimq-server nrpe monitor basic functionality."""
+        try:
+            zaza.model.get_application("nrpe")
+        except KeyError:
+            logging.warn(("Skipping as nrpe is not deployed. "
+                          "http://pad.lv/1968008"))
+            return
+
         units = zaza.model.get_units(self.application_name)
         host_names = generic_utils.get_unit_hostnames(units)
 


### PR DESCRIPTION
When the nrpe application is not deployed in the model skip the test
that checks for the correct configuration of the nagios checks, this is
because at the moment nrpe has no support for jammy, hence is not being
deployed in the jammy-yoga bundles.

Jammy support for nrpe is tracked at http://pad.lv/1968008