### PR TITLE
Reduce the number of pgs on pool creation.

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -272,19 +272,12 @@ class CephTest(test_utils.OpenStackBaseTest):
         Create a pool, add a text file to it and retrieve its content.
         Verify that the content matches the original file.
         """
-        issue = 'github.com/openstack-charmers/zaza-openstack-tests/issues/647'
-        current_release = zaza_openstack.get_os_release()
-        focal_victoria = zaza_openstack.get_os_release('focal_victoria')
-        if current_release >= focal_victoria:
-            logging.warn('Skipping test_ceph_pool_creation_with_text_file due'
-                         ' to issue {}'.format(issue))
-            return
-
         unit_name = 'ceph-mon/0'
-        cmd = 'sudo ceph osd pool create test 128; \
+        cmd = 'sudo ceph osd pool create test {PG_NUM}; \
                echo 123456789 > /tmp/input.txt; \
                rados put -p test test_input /tmp/input.txt; \
                rados get -p test test_input /dev/stdout'
+        cmd = cmd.format(PG_NUM=32)
         logging.debug('Creating test pool and putting test file in pool...')
         result = zaza_model.run_on_unit(unit_name, cmd)
         code = result.get('Code')


### PR DESCRIPTION
This change reduces the number of pgs requested on the creation of a
test pool to make it suitable for a 3 OSDs cluster.

Fixes: #647