### PR TITLE
Skip CeilometerTest.test_901_pause_resume for ceilometer-agent

### DIFF
--- a/zaza/openstack/charm_tests/ceilometer/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer/tests.py
@@ -160,5 +160,10 @@ class CeilometerTest(test_utils.OpenStackBaseTest):
         Pause service and check services are stopped then resume and check
         they are started.
         """
+        if self.application_name == 'ceilometer-agent':
+            logging.info("ceilometer-agent doesn't have pause/resume actions "
+                         "anymore, skipping")
+            return
+
         with self.pause_resume(self.restartable_services):
             logging.info("Testing pause and resume")


### PR DESCRIPTION
The ceilometer-agent charm doesn't have pause/resume
actions anymore. The ceilometer charm still does.

See https://bugs.launchpad.net/charm-ceilometer-agent/+bug/1952882

(cherry picked from commit 3e7ac87a79b567b4b5471bcb61f2890fbab809e1)