### PR TITLE
Get ceph-dashboard's public addresses from the mon

### DIFF
--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -126,7 +126,7 @@ class CephDashboardTest(test_utils.BaseCharmTest):
     def test_dashboard_units(self):
         """Check dashboard units are configured correctly."""
         verify = self.local_ca_cert
-        units = zaza.model.get_units(self.application_name)
+        units = zaza.model.get_units('ceph-mon')
         rcs = collections.defaultdict(list)
         for unit in units:
             r = self._run_request_get(


### PR DESCRIPTION
At some point, Juju stopped returning a list of units for subordinate
charms, so this test now fails to find the address for the dashboard units