### PR TITLE
Set tempest octavia provider to amphora.

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -119,4 +119,5 @@ backup = false
 enable_security_groups = true
 test_with_ipv6 = false
 test_server_path = {{ workspace_path }}/test_server.bin
+provider = amphora
 {% endif %}


### PR DESCRIPTION
By default the provider that will be used by tempest is "octavia" which
in Octavia's default configuration is an alias of amphora, although in a
Charmed OpenStack is not.

This change sets the provider to be used by octavia-tempest-plugin to
amphora.