### PR TITLE
Fix VM retryer

### DIFF
--- a/zaza/openstack/configure/guest.py
+++ b/zaza/openstack/configure/guest.py
@@ -68,7 +68,7 @@ def launch_instance_retryer(instance_key, **kwargs):
         keystone_session = openstack_utils.get_overcloud_keystone_session()
         nova_client = openstack_utils.get_nova_session_client(keystone_session)
         vm = nova_client.servers.find(name=vm_name)
-        openstack_utils.resource_removed(
+        openstack_utils.delete_resource(
             nova_client.servers,
             vm.id,
             msg="Waiting for the Nova VM {} to be deleted".format(vm.name))


### PR DESCRIPTION
I recently added an option to have zaza delete and relaunch a
guest if it failed to be provisioned or failed a connectivity
test. However, in the code to remove the an instance I
accidentaly called the method that checks that a resource has
gone and not the method that actually does the removal. This
patch fixes that. NOTE: Only the Trilio tests use this
retryer function atm