### PR TITLE
Stop failing on unknown ceilometer metrics

### DIFF
--- a/zaza/openstack/charm_tests/ceilometer_agent/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer_agent/tests.py
@@ -92,7 +92,7 @@ class CeilometerAgentTest(test_utils.OpenStackBaseTest):
         unexpected_found_metric_names = (
             found_metric_names - expected_metric_names)
         if len(unexpected_found_metric_names) > 0:
-            self.fail(
+            logging.info(
                 'Unexpected metrics '
                 'published: ' + ', '.join(unexpected_found_metric_names))
 


### PR DESCRIPTION
The metric test is too strict and fails if it finds a metric that
is not explicitly listed in the test. Given the test does check
that the expected metrics are present there seems not need to fail
if a new one has added upstream.
