### PR TITLE
 Remove check_haproxy if hacluster is present in the bundle

### DIFF
--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -91,6 +91,14 @@ class ManilaTests(test_utils.OpenStackBaseTest):
         units = zaza.model.get_units('manila')
         services = ['apache2', 'haproxy', 'manila-scheduler', 'manila-data']
 
+        # Remove check_haproxy if hacluster is present in the bundle
+        # See LP Bug#1880601 for details
+        try:
+            if zaza.model.get_units('hacluster'):
+                services.remove("haproxy")
+        except KeyError:
+            pass
+
         cmds = []
         for check_name in services:
             cmds.append(


### PR DESCRIPTION
Since patch https://github.com/juju/charm-helpers/commit/96a6befda83425800ce93759b9864aba67af731e, if hacluster is present in the bundle, check_crm shall monitor haproxy.  
This patch checks if hacluster is present in the bundle, if so it remove haproxy from services array

Closes Issue: #817 