### PR TITLE
Add zaza.clean_up_libjuju_thread

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack_upgrade.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack_upgrade.py
@@ -15,7 +15,12 @@
 import mock
 
 import unit_tests.utils as ut_utils
+import zaza
 import zaza.openstack.utilities.openstack_upgrade as openstack_upgrade
+
+
+def tearDownModule():
+    zaza.clean_up_libjuju_thread()
 
 
 class TestOpenStackUpgradeUtils(ut_utils.BaseTestCase):


### PR DESCRIPTION
Since a recent update to zaza to put libjuju asyncio on a background
thread the openstack upgrade action tests have been causing the
whole unit tests run to hang. It looks like nose is waiting for
threads to be cleaned up. This change mirrors the chance from zaza
to add the cleanup.