### PR TITLE
Ensure unittests use zaza non-threaded

### DIFF
--- a/unit_tests/__init__.py
+++ b/unit_tests/__init__.py
@@ -11,3 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# force zaza to not use threads for async
+import zaza
+
+zaza.RUN_LIBJUJU_IN_THREAD = False


### PR DESCRIPTION
zaza normally runs libjuju async functions in a background thread
to enable zaza to be blocking, but keep the libjuju async functions
'ticking over' between blocking calls.

This can break unit tests as starting the zaza background thread will
hang unless it is cleaned up.  A simple solution is just to use zaza in
non-threaded mode in the unit tests, and zaza provides a mechanism for
this via zaza.RUN_LIBJUJU_IN_THREAD = False.