### PR TITLE
Add Testcases for Ceph-RGW multisite migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ lxml<4.6.3
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
-boto3
+boto3<1.25
 juju!=2.8.3  # blacklist 2.8.3 as it appears to have a connection bug
 juju_wait
 PyYAML<=4.2,>=3.0

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -892,8 +892,8 @@ class CephRGWTest(test_utils.OpenStackBaseTest):
                 "ceph-radosgw", "ceph-radosgw:master",
                 "slave-ceph-radosgw:slave"
             )
+            zaza_model.block_until_unit_wl_status('ceph-radosgw/0', "blocked")
 
-        zaza_model.block_until_unit_wl_status('ceph-radosgw/0', "blocked")
         zaza_model.block_until_unit_wl_status('ceph-radosgw/0', "active")
         self.wait_for_sync('slave-ceph-radosgw', isPrimary=False)
         self.wait_for_sync('ceph-radosgw', isPrimary=True)

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1023,11 +1023,11 @@ class CephRGWTest(test_utils.BaseCharmTest):
                 self.secondary_rgw_app + ":slave"
             )
             zaza_model.block_until_unit_wl_status(
-                self.secondary_rgw_app + "/0", "waiting"
+                self.secondary_rgw_unit, "waiting"
             )
-        logging.info('Waiting for model to stabalize')
+
         zaza_model.block_until_unit_wl_status(
-            self.secondary_rgw_app + "/0", "active"
+            self.secondary_rgw_unit, "active"
         )
         logging.info('Waiting for Data and Metadata to Synchronize')
         self.wait_for_sync(self.secondary_rgw_app, isPrimary=False)
@@ -1075,12 +1075,8 @@ class CephRGWTest(test_utils.BaseCharmTest):
 
         logging.info('Checking multisite failover/failback')
         # Create RGW IO client.
-        primary_endpoint = self.get_rgw_endpoint(
-            self.primary_rgw_app + "/0"
-        )
-        secondary_endpoint = self.get_rgw_endpoint(
-            self.secondary_rgw_app + "/0"
-        )
+        primary_endpoint = self.get_rgw_endpoint(self.primary_rgw_unit)
+        secondary_endpoint = self.get_rgw_endpoint(self.secondary_rgw_unit)
         access_key, secret_key = self.get_client_keys() 
         primary_client = boto3.resource("s3",
                                         verify=False,

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -711,7 +711,7 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Get radosgw-admin cmd skeleton with rgw.hostname populated key.
 
         :param unit_name: Unit on which the complete command would be run.
-        :ptype unit_name: str
+        :type unit_name: str
         :returns: hostname filled basic command skeleton
         :rtype: str
         """
@@ -729,9 +729,9 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Wait for slave to secondary to show it is in sync.
 
         :param application: RGW application which has to be waited for
-        :ptype application: str
+        :type application: str
         :param is_primary: whether application is primary site endpoint
-        :ptype is_primary: boolean
+        :type is_primary: boolean
         """
         juju_units = zaza_model.get_units(application)
         unit_hostnames = generic_utils.get_unit_hostnames(juju_units)
@@ -755,11 +755,11 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Fetch RGW object content.
 
         :param target_client: boto3 client object configured for an endpoint.
-        :ptype target_client: str
+        :type target_client: str
         :param container_name: RGW bucket name for desired object.
-        :ptype container_name: str
+        :type container_name: str
         :param object_name: Object name for desired object.
-        :ptype object_name: str
+        :type object_name: str
         """
         return target_client.Object(container_name, object_name).get()[
             'Body'
@@ -770,7 +770,7 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Promote provided app to Primary and update period at new secondary.
 
         :param app_name: Secondary site rgw Application to be promoted.
-        :ptype app_name: str
+        :type app_name: str
         """
         if app_name is self.primary_rgw_app:
             new_secondary = self.secondary_rgw_unit
@@ -795,7 +795,7 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Create access_key and secret_key for boto3 client.
 
         :param rgw_app_name: RGW application for which keys are required.
-        :ptype rgw_app_name: str
+        :type rgw_app_name: str
         """
         unit_name = self.primary_rgw_unit
         if rgw_app_name is not None:
@@ -832,7 +832,7 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Fetch Application endpoint for RGW unit.
 
         :param unit_name: Unit name for which RGW endpoint is required.
-        :ptype unit_name: str
+        :type unit_name: str
         """
         unit = zaza_model.get_unit_from_name(unit_name)
         unit_address = zaza_model.get_unit_public_address(
@@ -877,7 +877,7 @@ class CephRGWTest(test_utils.BaseCharmTest):
         Clear Multisite Juju config values to default.
 
         :param app_name: App for which config values are to be cleared
-        :ptype app_name: str
+        :type app_name: str
         """
         unit_name = app_name + "/0"
         zaza_model.set_application_config(


### PR DESCRIPTION
1. Added Auxiliary methods and refactored code.
2. Switched to Boto3 (from Swift Client) for accessing individual endpoints.
3. A new test for (non-pristine) secondary site migration block is added.
4. 2 existing (but redundant) Data Integrity test cases are merged as 1 logically structured test-case.
5. Failover and Recovery test-case is passing on multisite models.

Tests used by: https://review.opendev.org/c/openstack/charm-ceph-radosgw/+/848739