### PR TITLE
Add glance-simplestreams-sync --set-latest-property functest

### DIFF
--- a/zaza/openstack/charm_tests/glance_simplestreams_sync/setup.py
+++ b/zaza/openstack/charm_tests/glance_simplestreams_sync/setup.py
@@ -21,6 +21,7 @@ import tenacity
 import pprint
 
 import zaza.model as zaza_model
+import zaza.charm_lifecycle.utils as lifecycle_utils
 import zaza.openstack.utilities.generic as generic_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 
@@ -77,3 +78,17 @@ def sync_images():
         logging.info('Contents of Keystone service catalog: "{}"'
                      .format(pprint.pformat(catalog)))
         raise
+
+
+def set_latest_property_config():
+    """Enable set_latest_property config.
+
+    This config adds `latest=true` to new synced images.
+    """
+    logging.info("Change config `set_latest_property=true`")
+    zaza_model.set_application_config('glance-simplestreams-sync',
+                                      {'set_latest_property': 'true',
+                                       'snap-channel': 'edge'})
+    test_config = lifecycle_utils.get_charm_config(fatal=False)
+    zaza_model.wait_for_application_states(
+        states=test_config.get('target_deploy_status', {}))

--- a/zaza/openstack/charm_tests/glance_simplestreams_sync/tests.py
+++ b/zaza/openstack/charm_tests/glance_simplestreams_sync/tests.py
@@ -125,3 +125,23 @@ class GlanceSimpleStreamsSyncTest(test_utils.OpenStackBaseTest):
         _check_local_product_streams(expected_images)
 
         logging.debug("Local product stream successful")
+
+
+class GlanceSimpleStreamsSyncWithPropertiesTest(GlanceSimpleStreamsSyncTest):
+    """Glance Simple Streams Sync Test with Image property.
+
+    `setup.py:set_latest_property_config()` is required by this test and it is
+    called during charm-glance-simplestreams-sync/tests/tests.yaml:configure
+    phase.
+    """
+
+    # TODO(guimalufb) test if the latest property gets removed from old images
+    def test_200_check_image_latest_property(self):
+        """Verify that images had metadata property set."""
+        logging.debug("Checking images with latest=true property...")
+
+        filter_properties = {'filters': {'latest': 'true'}}
+        images = self.glance_client.images.list(**filter_properties)
+        self.assertTrue(len(list(images)) > 0,
+                        "'latest=true' property not found in glance images"
+                        " list")


### PR DESCRIPTION
When creating Openstack VMs the user has to specify the image it wants
to use. sstream-mirror-glance adds a date to the image name, so they
always have to recheck which is the current latest image.

This commit tests the usage of the `set-latest-property` configuration.

When set-latest-property is given sstream-mirror-glance will set the
recently synced image with the `latest=true` property and then remove
the `latest` property from all the os_version/architecture matching
images.

Closes-bug: LP #1933130