### PR TITLE
Remove libjuju and juju_wait dependency in zaza-openstack-tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
 boto3<1.25
-juju!=2.8.3  # blacklist 2.8.3 as it appears to have a connection bug
-juju_wait
 PyYAML<=4.2,>=3.0
 flake8>=2.2.4
 flake8-docstrings

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ install_require = [
     'dnspython',
     'hvac<0.7.0',
     'jinja2',
-    'juju',
-    'juju-wait',
     'lxml',
     'PyYAML',
     'tenacity',


### PR DESCRIPTION
This dependency is available via zaza already, and more
clearly illustrates the origin of dependencies.