### PR TITLE
Strip trailing slash from dashboard URL

### DIFF
--- a/zaza/openstack/charm_tests/ceph/dashboard/tests.py
+++ b/zaza/openstack/charm_tests/ceph/dashboard/tests.py
@@ -168,7 +168,7 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         url = json.loads(output).get('dashboard')
         if url is None:
             raise tenacity.RetryError(None)
-        return url
+        return url.strip('/')
 
     def test_dashboard_units(self):
         """Check dashboard units are configured correctly."""


### PR DESCRIPTION
The trailing slash gets handled badly by the Ceph dashboard when
the auth URL ends up looking like https://ip.address//api/auth