### PR TITLE
Update LTS image from Bionic (18.04) to Jammy (22.04)

### DIFF
--- a/zaza/openstack/charm_tests/glance/setup.py
+++ b/zaza/openstack/charm_tests/glance/setup.py
@@ -24,8 +24,8 @@ import zaza.utilities.deployment_env as deployment_env
 
 CIRROS_IMAGE_NAME = "cirros"
 CIRROS_ALT_IMAGE_NAME = "cirros_alt"
-LTS_RELEASE = "bionic"
-LTS_IMAGE_NAME = "bionic"
+LTS_RELEASE = "jammy"
+LTS_IMAGE_NAME = "jammy"
 
 
 def basic_setup():


### PR DESCRIPTION
Ubuntu 22.04.1 was released and it should be used as the new baseline
for testing in the gate.