### PR TITLE
Added tests for charm-openstack-dashboard

### DIFF
--- a/zaza/openstack/charm_tests/openstack_dashboard/tests.py
+++ b/zaza/openstack/charm_tests/openstack_dashboard/tests.py
@@ -456,6 +456,60 @@ class OpenStackDashboardTests(test_utils.OpenStackBaseTest,
         with self.pause_resume(['apache2']):
             logging.info("Testing pause resume")
 
+    def test_920_get_noncacheable_content_and_check_cookie(self):
+        """Login and check cache cookies.
+
+        All non-cacheable content should have all the following headers:
+
+        Cache-Control: no-store
+        Pragma: no-cache
+        """
+        logging.info("Testing caching headers on non-cacheable content.")
+        overcloud_auth = openstack_utils.get_overcloud_auth()
+        password = overcloud_auth['OS_PASSWORD']
+
+        domain = 'admin_domain'
+        username = 'admin'
+        client, response = _login(
+            self.get_horizon_url(), domain, username, password,
+            cafile=self.cacert)
+
+        expected_headers = {
+            "cache-control": "no-store",
+            "pragma": "no-cache"
+        }
+        for header, value in expected_headers.items():
+            self.assertIn(value, response.headers.get(header, "none").lower())
+
+    def test_930_get_cacheable_content_and_check_cookie(self):
+        """Get random static file and check cookies.
+
+        Cachable files should not have any of the following headers:
+
+        Cache-Control: no-store
+        Pragma: no-cache
+        """
+        logging.info("Testing caching headers on cacheable content.")
+        unit_name = zaza_model.get_lead_unit_name('openstack-dashboard')
+        static_files_location = "/var/lib/openstack-dashboard/static/"
+        cmd = 'find {} -iname ''*.css'' -type f | sort -R | ' \
+              'sed "s#/var/lib/openstack-dashboard##" | head -1' \
+            .format(static_files_location)
+        output = zaza_model.run_on_unit(unit_name, cmd)
+        url = "{}{}".format(self.get_horizon_url(), output['Stdout'].strip())
+
+        unexpected_headers = {
+            "cache-control": "no-store",
+            "pragma": "no-cache"
+        }
+
+        client = requests.session()
+        response = client.get(url, verify=self.cacert, timeout=30)
+
+        for header, value in unexpected_headers.items():
+            self.assertNotIn(value,
+                             response.headers.get(header, "none").lower())
+
 
 class OpenStackDashboardPolicydTests(policyd.BasePolicydSpecialization,
                                      OpenStackDashboardBase):


### PR DESCRIPTION
Added tests for checking positive and negative matches for the `Cache-Control` and `Pragma` http headers.

If the requested resource is static ensure these headers are not set. Random static file used for testing.
```
Cache-Control: no-store
Pragma: no-cache
```

If the requested resource is dynamic ensure these headers are set. Login page used for testing.
```
Cache-Control: no-store
Pragma: no-cache
```

Closes-Bug: [#1836518](https://bugs.launchpad.net/charm-openstack-dashboard/+bug/1836518) 