### PR TITLE
Support LTS_IMAGE_NAME(jammy) in guest.launch_instance

### DIFF
--- a/zaza/openstack/configure/guest.py
+++ b/zaza/openstack/configure/guest.py
@@ -47,7 +47,13 @@ boot_tests = {
         'image_name': 'focal',
         'flavor_name': 'm1.small',
         'username': 'ubuntu',
-        'bootstring': 'finished at'}}
+        'bootstring': 'finished at'},
+    'jammy': {
+        'image_name': 'jammy',
+        'flavor_name': 'm1.small',
+        'username': 'ubuntu',
+        'bootstring': 'finished at'}
+}
 
 
 def launch_instance_retryer(instance_key, **kwargs):


### PR DESCRIPTION
To be tested in:
https://review.opendev.org/c/openstack/charm-cinder/+/848914


Follow-up of #860 and #791 to fix:

 File "./zaza/openstack/charm_tests/test_utils.py", line 798, in launch_guest
   return configure_guest.launch_instance(
 File "./zaza/openstack/configure/guest.py", line 128, in launch_instance
   image_name = image_name or boot_tests[instance_key]['image_name']
KeyError: 'jammy'