### PR TITLE
Fix pep8 lint errors

### DIFF
--- a/zaza/openstack/charm_tests/barbican/tests.py
+++ b/zaza/openstack/charm_tests/barbican/tests.py
@@ -36,7 +36,7 @@ class BarbicanTest(test_utils.OpenStackBaseTest):
             actual_interfaces = [endpoint['interface'] for endpoint in
                                  actual_endpoints[service_type]]
             for expected_interface in ('internal', 'admin', 'public'):
-                assert(expected_interface in actual_interfaces)
+                assert expected_interface in actual_interfaces
 
     def test_400_api_connection(self):
         """Simple api calls to check service is up and responding."""
@@ -57,7 +57,7 @@ class BarbicanTest(test_utils.OpenStackBaseTest):
 
         logging.info('Storing the secret')
         my_secret_ref = my_secret.store()
-        assert(my_secret_ref is not None)
+        assert my_secret_ref is not None
 
         logging.info('Deleting the secret')
         my_secret.delete()

--- a/zaza/openstack/charm_tests/ceilometer/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer/tests.py
@@ -112,8 +112,8 @@ class CeilometerTest(test_utils.OpenStackBaseTest):
         )
 
         logging.info('Checking api functionality...')
-        assert(ceil.samples.list() == [])
-        assert(ceil.meters.list() == [])
+        assert ceil.samples.list() == []
+        assert ceil.meters.list() == []
 
     def test_900_restart_on_config_change(self):
         """Checking restart happens on config change."""

--- a/zaza/openstack/charm_tests/ceph/mon/tests.py
+++ b/zaza/openstack/charm_tests/ceph/mon/tests.py
@@ -163,7 +163,7 @@ def invert_condition(async_condition):
     :rtype: Coroutine[[], bool]
     """
     async def _async_invert_condition_closure():
-        return not(await async_condition())
+        return not (await async_condition())
     return _async_invert_condition_closure
 
 

--- a/zaza/openstack/charm_tests/gnocchi/tests.py
+++ b/zaza/openstack/charm_tests/gnocchi/tests.py
@@ -53,7 +53,7 @@ class GnocchiTest(test_utils.OpenStackBaseTest):
         )
 
         logging.info('Checking api functionality...')
-        assert(gnocchi.status.get() != [])
+        assert gnocchi.status.get() != []
 
     def test_910_pause_resume(self):
         """Run pause and resume tests.

--- a/zaza/openstack/charm_tests/ironic/tests.py
+++ b/zaza/openstack/charm_tests/ironic/tests.py
@@ -42,7 +42,7 @@ class IronicTest(test_utils.OpenStackBaseTest):
         actual_interfaces = [endpoint['interface'] for endpoint in
                              actual_endpoints["baremetal"]]
         for expected_interface in ('internal', 'admin', 'public'):
-            assert(expected_interface in actual_interfaces)
+            assert expected_interface in actual_interfaces
 
     def test_400_api_connection(self):
         """Simple api calls to check service is up and responding."""
@@ -50,7 +50,7 @@ class IronicTest(test_utils.OpenStackBaseTest):
 
         logging.info('listing conductors')
         conductors = ironic.conductor.list()
-        assert(len(conductors) > 0)
+        assert len(conductors) > 0
 
         # By default, only IPMI HW type is enabled. iDrac and Redfish
         # can optionally be enabled
@@ -59,8 +59,8 @@ class IronicTest(test_utils.OpenStackBaseTest):
 
         expected = ['intel-ipmi', 'ipmi']
         for exp in expected:
-            assert(exp in driver_names)
-        assert(len(driver_names) == 2)
+            assert exp in driver_names
+        assert len(driver_names) == 2
 
     def test_900_restart_on_config_change(self):
         """Checking restart happens on config change.

--- a/zaza/openstack/charm_tests/nova/tests.py
+++ b/zaza/openstack/charm_tests/nova/tests.py
@@ -517,13 +517,13 @@ class NovaCloudController(NovaCommonTests):
                                 nova.services.list()]
         for expected_service_name in ('nova-scheduler', 'nova-conductor',
                                       'nova-compute'):
-            assert(expected_service_name in actual_service_names)
+            assert expected_service_name in actual_service_names
 
         # Thanks to setup.create_flavors we should have a few flavors already:
-        assert(len(nova.flavors.list()) > 0)
+        assert len(nova.flavors.list()) > 0
 
         # Just checking it's not raising and returning an iterable:
-        assert(len(nova.servers.list()) >= 0)
+        assert len(nova.servers.list()) >= 0
 
     def test_106_compute_catalog_endpoints(self):
         """Verify that the compute endpoints are present in the catalog."""
@@ -537,12 +537,12 @@ class NovaCloudController(NovaCommonTests):
         if self.current_release < self.XENIAL_QUEENS:
             actual_compute_endpoints = actual_endpoints['compute'][0]
             for expected_url in ('internalURL', 'adminURL', 'publicURL'):
-                assert(expected_url in actual_compute_endpoints)
+                assert expected_url in actual_compute_endpoints
         else:
             actual_compute_interfaces = [endpoint['interface'] for endpoint in
                                          actual_endpoints['compute']]
             for expected_interface in ('internal', 'admin', 'public'):
-                assert(expected_interface in actual_compute_interfaces)
+                assert expected_interface in actual_compute_interfaces
 
     def test_220_nova_metadata_propagate(self):
         """Verify that the vendor-data settings are propagated.

--- a/zaza/openstack/configure/network.py
+++ b/zaza/openstack/configure/network.py
@@ -184,7 +184,8 @@ def setup_sdn(network_config, keystone_session=None):
 
 
 def setup_sdn_provider_vlan(network_config, keystone_session=None):
-    """Perform setup for Software Defined Network, specifically a provider VLAN.
+    """
+    Perform setup for Software Defined Network, specifically a provider VLAN.
 
     :param network_config: Network configuration settings dictionary
     :type network_config: dict

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -555,7 +555,8 @@ def get_keystone_session_client(session, client_api_version=3):
 
 
 def get_keystone_client(openrc_creds, verify=None):
-    """Return authenticated keystoneclient and set auth_ref for service_catalog.
+    """
+    Return authenticated keystoneclient and set auth_ref for service_catalog.
 
     :param openrc_creds: OpenStack RC credentials
     :type openrc_creds: dict
@@ -2915,7 +2916,7 @@ def ssh_command(username,
         try:
             verify(stdin, stdout, stderr)
         except Exception as e:
-            raise(e)
+            raise e
         finally:
             ssh.close()
 


### PR DESCRIPTION
One of the pep8 target dependencies must have updated,
causing a bunch of new lint errors in these categories:
- line length > 79 chars
- no whitespace after keyword