### PR TITLE
Respect model in get_swift_storage_topology

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_swift.py
+++ b/unit_tests/utilities/test_zaza_utilities_swift.py
@@ -93,7 +93,7 @@ class TestSwiftUtils(ut_utils.BaseTestCase):
         self.patch_object(zaza.model, 'get_units')
         self.patch_object(zaza.model, 'get_unit_public_address')
 
-        def _get_unit_public_address(u):
+        def _get_unit_public_address(u, model_name=None):
             return u.public_address
 
         self.get_unit_public_address.side_effect = _get_unit_public_address

--- a/zaza/openstack/utilities/swift.py
+++ b/zaza/openstack/utilities/swift.py
@@ -207,7 +207,10 @@ def get_swift_storage_topology(model_name=None):
             region = app_config['storage-region']['value']
             zone = app_config['zone']['value']
             for unit in zaza.model.get_units(app_name, model_name=model_name):
-                topology[zaza.model.get_unit_public_address(unit)] = {
+                unit_ip = zaza.model.get_unit_public_address(
+                    unit,
+                    model_name=model_name)
+                topology[unit_ip] = {
                     'app_name': app_name,
                     'unit': unit,
                     'region': region,


### PR DESCRIPTION
Change 0af4c93d causes the target model to be ignored when a
model_name was specified. This in turn is causing the swift
cmr tests to fail as an ip of None is being recorded for
units in a different model.