### PR TITLE
Fix Ganesha _restart_share_instance for non-ha

### DIFF
--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -50,6 +50,7 @@ class ManilaGaneshaTests(manila_tests.ManilaBaseTest):
         ganeshas = [
             app for app in zaza.model.sync_deployed()
             if 'ganesha' in app and 'mysql' not in app]
+        logging.info('Found ganeshas: {}'.format(ganeshas))
         for ganesha in ganeshas:
             ganesha_unit = zaza.model.get_units(ganesha)[0]
             hacluster_unit = zaza_utils_juju.get_subordinate_units(

--- a/zaza/openstack/charm_tests/manila_ganesha/tests.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/tests.py
@@ -48,9 +48,11 @@ class ManilaGaneshaTests(manila_tests.ManilaBaseTest):
         # this is a best-guestimate arrived at by looking for applications
         # with the word 'ganesha' in their names.
         ganeshas = [
-            app for app in zaza.model.sync_deployed()
+            app for app in zaza.model.sync_deployed(model_name=self.model_name)
             if 'ganesha' in app and 'mysql' not in app]
-        logging.info('Found ganeshas: {}'.format(ganeshas))
+        logging.info('Found ganeshas in model {}: {}'.format(
+            self.model_name,
+            ganeshas))
         for ganesha in ganeshas:
             ganesha_unit = zaza.model.get_units(ganesha)[0]
             hacluster_unit = zaza_utils_juju.get_subordinate_units(


### PR DESCRIPTION
Manila Ganesha is not always deployed in an ha configuration in functional tests. But the _restart_share_instance method shuts down manila services via systemctl and expects them to be automatically started. This change detects if the hacluster charm is present, if it is it uses the old behaviour otherwise systemctl is used to restart the services.

Test run without ha manila ganesha:
https://openstack-ci-reports.ubuntu.com/artifacts/642/856330/7/check/ganesha-focal-xena/6421186/job-output.txt

Test run with ha manila ganesha:
https://openstack-ci-reports.ubuntu.com/artifacts/bff/856459/1/check/focal-xena/bffb34c/job-output.txt