### PR TITLE
Set manila snapshot capability back to False

### DIFF
--- a/zaza/openstack/charm_tests/manila_ganesha/setup.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/setup.py
@@ -42,5 +42,5 @@ def setup_ganesha_share_type(manila_client=None):
         extra_specs={
             'vendor_name': 'Ceph',
             'storage_protocol': 'NFS',
-            'snapshot_support': True,
+            'snapshot_support': False,
         })


### PR DESCRIPTION
Manila Ganesha does not support snapshots prior to wallaby.

(cherry picked from commit b81e555939624fd0741971225b80c5c862ec67d8)