### PR TITLE
Fix dashboard policy tests.

### DIFF
--- a/zaza/openstack/charm_tests/openstack_dashboard/tests.py
+++ b/zaza/openstack/charm_tests/openstack_dashboard/tests.py
@@ -530,7 +530,7 @@ class OpenStackDashboardPolicydTests(policyd.BasePolicydSpecialization,
     })}
 
     # url associated with rule above that will return HTTP 403
-    url = "http://{}/horizon/identity/domains"
+    url = "{}/identity/domains"
 
     @classmethod
     def setUpClass(cls, application_name=None):
@@ -565,7 +565,7 @@ class OpenStackDashboardPolicydTests(policyd.BasePolicydSpecialization,
             self.get_horizon_url(), domain, username, password,
             cafile=self.cacert)
         # now attempt to get the domains page
-        _url = self.url.format(zaza_model.get_unit_public_address(unit))
+        _url = self.url.format(self.get_horizon_url())
         logging.info("URL is {}".format(_url))
         result = client.get(_url)
         if result.status_code == 403:


### PR DESCRIPTION
The dashboard policyd  override tests assume the deloyment is http and non-ha. This is not a safe assumption so use the existing code to generate the correct domain listing url.