### PR TITLE
Fix keystone ip

### DIFF
--- a/zaza/openstack/charm_tests/saml_mellon/tests.py
+++ b/zaza/openstack/charm_tests/saml_mellon/tests.py
@@ -282,10 +282,6 @@ class BaseCharmKeystoneSAMLMellonTest(BaseKeystoneTest):
 
     def test_saml_mellon_redirects(self):
         """Validate the horizon -> keystone -> IDP redirects."""
-        unit = zaza.model.get_units(self.application_name)[0]
-        keystone_ip = self.vip if self.vip else (
-            zaza.model.get_unit_public_address(unit))
-
         horizon = "openstack-dashboard"
         horizon_config = zaza.model.get_application_config(horizon)
         horizon_vip = horizon_config.get("vip").get("value")
@@ -297,6 +293,11 @@ class BaseCharmKeystoneSAMLMellonTest(BaseKeystoneTest):
 
         # Use Keystone URL for < Stein
         if self.current_release < self.BIONIC_STEIN:
+            keystone_config = zaza.model.get_application_config('keystone')
+            keystone_ip = keystone_config.get("vip").get("value")
+            if not keystone_ip:
+                keystone_unit = zaza.model.get_units('keystone')[0]
+                keystone_ip = zaza.model.get_unit_public_address(keystone_unit)
             region = "{}://{}:5000/v3".format(proto, keystone_ip)
         else:
             region = "default"


### PR DESCRIPTION
The code to get the keystone ip incorrectly assumes that self.application_name is 'keystone' whereas it is
'keystone-saml-mellonX'. This causes the unit ip lookup to fail as it is a subordinate. This only affects deployments pre-stein as after that the keystone ip is not used.