### PR TITLE
Separate DPDK tests from other chassis tests

### DIFF
--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -296,6 +296,10 @@ class ChassisCharmOperationTest(BaseCharmOperationTest):
                 msg='OVS unexpectedly has DPDK initialized'):
             self._ovs_dpdk_initialized()
 
+
+class DPDKTest(test_utils.BaseCharmTest):
+    """DPDK-related tests."""
+
     def test_enable_dpdk(self):
         """Confirm that transitioning to/from DPDK works."""
         logging.info('Pre-flight check')


### PR DESCRIPTION
We do not yet support DPDK for ovn-dedicated-chassis, therefore, we need
to avoid running DPDK func tests for it.