### PR TITLE
Pin pyopenssl<22.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,11 @@ lxml<4.6.3
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
+# pyopenssl depends on a newer version of cryptography since 22.1.0
+# TypeError: deprecated() got an unexpected keyword argument 'name'
+# https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
+pyopenssl<22.1.0
+
 boto3<1.25
 PyYAML<=4.2,>=3.0
 flake8>=2.2.4


### PR DESCRIPTION
pyopenssl depends on a newer version of cryptography since 22.1.0.

https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f