### PR TITLE
Pin pyopenssl<22.1.0 (#930) [wallaby backport]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,11 @@ async_generator
 boto3
 juju!=2.8.3  # blacklist 2.8.3 as it appears to have a connection bug
 juju_wait
+# pyopenssl depends on a newer version of cryptography since 22.1.0
+# TypeError: deprecated() got an unexpected keyword argument 'name'
+# https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
+pyopenssl<22.1.0
+
 PyYAML<=4.2,>=3.0
 flake8>=2.2.4
 flake8-docstrings


### PR DESCRIPTION
pyopenssl depends on a newer version of cryptography since 22.1.0.

https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f

(cherry picked from commit 615d83c57d95b6c7d634bb3df3d5f4e24a48daf5)
