### PR TITLE
Pin pyOpenSSL in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ install_require = [
     'async_generator',
     'boto3',
 
+    # pyopenssl depends on a newer version of cryptography since 22.1.0
+    # TypeError: deprecated() got an unexpected keyword argument 'name'
+    # https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
+    'pyopenssl<22.1.0',
+
     # Newer versions require a Rust compiler to build, see
     # * https://github.com/openstack-charmers/zaza/issues/421
     # * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html


### PR DESCRIPTION
It was pinned in requirements.txt in https://github.com/openstack-charmers/zaza-openstack-tests/pull/930
but this isn't picked up when installing this via pip.
So, it needs to be pinned in the setup.py install_require list too.

To test this:

1. create a python virtual environment
2. `pip install 'git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza'`
3. `pip install 'git+https://github.com/swalladge/zaza-openstack-tests.git@pin-pyopenssl-setup-py#egg=zaza.openstack'`
4. `pip freeze | grep pyOpenSSL` # verify output has `pyOpenSSL` < `22.1.0`