### PR TITLE
Pin pyOpenSSL in setup.py [xena backport]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ install_require = [
     'async_generator',
     'boto3',
 
+    # pyopenssl depends on a newer version of cryptography since 22.1.0
+    # TypeError: deprecated() got an unexpected keyword argument 'name'
+    # https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
+    'pyopenssl<22.1.0',
+
     # Newer versions require a Rust compiler to build, see
     # * https://github.com/openstack-charmers/zaza/issues/421
     # * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html


### PR DESCRIPTION
It was pinned in requirements.txt,
but this isn't picked up when installing this via pip.
So, it needs to be pinned in the setup.py install_require list too.

(cherry picked from commit a6a540aebbce24bf5348d291115302dacfd2028a)