### PR TITLE
k8s: use action to retrieve admin password

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2140,9 +2140,13 @@ def _get_overcloud_auth_k8s(address=None, model_name=None):
             'applications']['keystone'].public_address
     address = network_utils.format_addr(address)
 
-    # This is hard-coded in the charm at the moment
-    logging.warning('Using hardcoded keystone password')
-    password = 'abc123'
+    logging.info('Retrieving admin password from keystone')
+    action = zaza.model.run_action_on_leader(
+        'keystone',
+        'get-admin-password',
+        action_params={}
+    )
+    password = action.data['results']['password']
 
     # V3 or later
     logging.info('Using keystone API V3 (or later) for overcloud auth')


### PR DESCRIPTION
The Keystone K8S operator now uses generated passwords; make use of the helper action to retrieve the admin password.