### PR TITLE
Update series upgrade automation

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_series_upgrade.py
+++ b/unit_tests/utilities/test_zaza_utilities_series_upgrade.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import mock
+import sys
+import unittest
 import unit_tests.utils as ut_utils
 import zaza.openstack.utilities.generic as generic_utils
 import zaza.openstack.utilities.series_upgrade as series_upgrade_utils
@@ -88,9 +91,19 @@ class TestSeriesUpgrade(ut_utils.BaseTestCase):
         self.set_origin.assert_called_once_with(_application, _origin)
         self.reboot.assert_called_once_with(_unit)
 
+    def _mock_app(self):
+        if sys.version_info < (3, 6, 0):
+            raise unittest.SkipTest("Can't AsyncMock in py35")
+        mock_get_action = mock.AsyncMock()
+        mock_get_action.get_actions.return_value = ["pause", "resume"]
+        mock_app = asyncio.Future()
+        mock_app.set_result(mock_get_action)
+        return mock_app
+
     def test_series_upgrade_application_pause_peers_and_subordinates(self):
-        self.patch_object(series_upgrade_utils.model, "run_action")
+        self.patch_object(series_upgrade_utils.model, "async_run_action")
         self.patch_object(series_upgrade_utils, "series_upgrade")
+        self.patch_object(series_upgrade_utils.model, "async_get_application")
         _application = "app"
         _from_series = "xenial"
         _to_series = "bionic"
@@ -108,6 +121,8 @@ class TestSeriesUpgrade(ut_utils.BaseTestCase):
             mock.call("{}/2".format(_application), "pause", action_params={}),
         ]
         _series_upgrade_calls = []
+        self.async_get_application.return_value = self._mock_app()
+        self.async_run_action.return_value = self._mock_app()
         for machine_num in ("0", "1", "2"):
             _series_upgrade_calls.append(
                 mock.call("{}/{}".format(_application, machine_num),
@@ -125,12 +140,13 @@ class TestSeriesUpgrade(ut_utils.BaseTestCase):
             pause_non_leader_subordinate=True,
             completed_machines=_completed_machines,
             workaround_script=_workaround_script, files=_files),
-        self.run_action.assert_has_calls(_run_action_calls)
+        self.async_run_action.assert_has_calls(_run_action_calls)
         self.series_upgrade.assert_has_calls(_series_upgrade_calls)
 
     def test_series_upgrade_application_pause_subordinates(self):
-        self.patch_object(series_upgrade_utils.model, "run_action")
+        self.patch_object(series_upgrade_utils.model, "async_run_action")
         self.patch_object(series_upgrade_utils, "series_upgrade")
+        self.patch_object(series_upgrade_utils.model, "async_get_application")
         _application = "app"
         _from_series = "xenial"
         _to_series = "bionic"
@@ -146,7 +162,8 @@ class TestSeriesUpgrade(ut_utils.BaseTestCase):
                       "pause", action_params={}),
         ]
         _series_upgrade_calls = []
-
+        self.async_get_application.return_value = self._mock_app()
+        self.async_run_action.return_value = self._mock_app()
         for machine_num in ("0", "1", "2"):
             _series_upgrade_calls.append(
                 mock.call("{}/{}".format(_application, machine_num),
@@ -164,7 +181,7 @@ class TestSeriesUpgrade(ut_utils.BaseTestCase):
             pause_non_leader_subordinate=True,
             completed_machines=_completed_machines,
             workaround_script=_workaround_script, files=_files),
-        self.run_action.assert_has_calls(_run_action_calls)
+        self.async_run_action.assert_has_calls(_run_action_calls)
         self.series_upgrade.assert_has_calls(_series_upgrade_calls)
 
     def test_series_upgrade_application_no_pause(self):

--- a/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
@@ -67,6 +67,7 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
         cls.from_series = None
         cls.to_series = None
         cls.workaround_script = None
+        cls.vault_unsealer = None
         cls.files = []
 
     def test_200_run_series_upgrade(self):
@@ -78,7 +79,7 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
             target_series=self.to_series)
         from_series = self.from_series
         to_series = self.to_series
-        vault_unsealer = getattr(self, "vault_unsealer", None)
+        vault_unsealer = self.vault_unsealer
         completed_machines = []
         workaround_script = None
         files = []
@@ -197,10 +198,21 @@ class BionicFocalSeriesUpgrade(OpenStackParallelSeriesUpgrade):
 
     @classmethod
     def setUpClass(cls):
-        """Run setup for Xenial to Bionic Series Upgrades."""
+        """Run setup for Bionic to Focal Series Upgrades."""
         super(BionicFocalSeriesUpgrade, cls).setUpClass()
         cls.from_series = "bionic"
         cls.to_series = "focal"
+
+
+class FocalJammySeriesUpgrade(OpenStackParallelSeriesUpgrade):
+    """OpenStack Bionic to FocalSeries Upgrade."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Run setup for Focal to Jammy Series Upgrades."""
+        super(BionicFocalSeriesUpgrade, cls).setUpClass()
+        cls.from_series = "focal"
+        cls.to_series = "jammy"
 
 
 class UbuntuLiteParallelSeriesUpgrade(unittest.TestCase):

--- a/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
+++ b/zaza/openstack/charm_tests/series_upgrade/parallel_tests.py
@@ -78,6 +78,7 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
             target_series=self.to_series)
         from_series = self.from_series
         to_series = self.to_series
+        vault_unsealer = getattr(self, "vault_unsealer", None)
         completed_machines = []
         workaround_script = None
         files = []
@@ -104,12 +105,13 @@ class ParallelSeriesUpgradeTest(unittest.TestCase):
             sem = asyncio.Semaphore(4)
             for charm_name in apps:
                 if applications[charm_name]["series"] == to_series:
-                    logging.info("{} already has series {}, skipping".format(
+                    logging.warn("{} already has series {}, skipping".format(
                         charm_name, to_series))
                     continue
                 charm = applications[charm_name]['charm']
                 name = upgrade_utils.extract_charm_name_from_url(charm)
-                upgrade_config = parallel_series_upgrade.app_config(name)
+                upgrade_config = parallel_series_upgrade.app_config(
+                    name, vault_unsealer)
                 upgrade_functions.append(
                     wrap_coroutine_with_sem(
                         sem,

--- a/zaza/openstack/utilities/parallel_series_upgrade.py
+++ b/zaza/openstack/utilities/parallel_series_upgrade.py
@@ -475,6 +475,9 @@ async def run_post_upgrade_functions(post_upgrade_functions):
     """
     if post_upgrade_functions:
         for func in post_upgrade_functions:
+            if callable(func):
+                func()
+                return
             logging.info("Running {}".format(func))
             m = cl_utils.get_class(func)
             await m()
@@ -488,12 +491,9 @@ async def run_post_application_upgrade_functions(post_upgrade_functions):
     """
     if post_upgrade_functions:
         for func in post_upgrade_functions:
-            if callable(func):
-                func()
-            else:
-                logging.info("Running {}".format(func))
-                m = cl_utils.get_class(func)
-                await m()
+            logging.info("Running {}".format(func))
+            m = cl_utils.get_class(func)
+            await m()
 
 
 async def maybe_pause_things(

--- a/zaza/openstack/utilities/series_upgrade.py
+++ b/zaza/openstack/utilities/series_upgrade.py
@@ -942,9 +942,7 @@ async def async_pause_helper(_type, unit):
     :param unit: Unit to pause
     """
     logging.info("Pausing ({}) {}".format(_type, unit))
-    print(model.async_get_application)
     app = await model.async_get_application(unit.split('/')[0])
-    print(app)
     if "pause" not in await app.get_actions():
         logging.info("Skipping pausing {} - no pause action"
                      .format(unit))

--- a/zaza/openstack/utilities/series_upgrade.py
+++ b/zaza/openstack/utilities/series_upgrade.py
@@ -22,14 +22,9 @@ import logging
 import os
 import time
 
-from zaza import model
+from zaza import model, sync_wrapper
 from zaza.charm_lifecycle import utils as cl_utils
 import zaza.openstack.utilities.generic as os_utils
-
-
-SUBORDINATE_PAUSE_RESUME_BLACKLIST = [
-    "cinder-ceph",
-]
 
 
 def app_config(charm_name, is_async=True):
@@ -166,14 +161,7 @@ def series_upgrade_non_leaders_first(
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    _app = subordinate.split('/')[0]
-                    if _app in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
-                        logging.info("Skipping pausing {} - blacklisted"
-                                     .format(subordinate))
-                    else:
-                        logging.info("Pausing {}".format(subordinate))
-                        model.run_action(
-                            subordinate, "pause", action_params={})
+                    pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
             logging.info("Pausing {}".format(unit))
             model.run_action(unit, "pause", action_params={})
@@ -270,14 +258,7 @@ async def async_series_upgrade_non_leaders_first(
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    _app = subordinate.split('/')[0]
-                    if _app in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
-                        logging.info("Skipping pausing {} - blacklisted"
-                                     .format(subordinate))
-                    else:
-                        logging.info("Pausing {}".format(subordinate))
-                        await model.async_run_action(
-                            subordinate, "pause", action_params={})
+                    await async_pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
             logging.info("Pausing {}".format(unit))
             await model.async_run_action(unit, "pause", action_params={})
@@ -375,14 +356,7 @@ def series_upgrade_application(application, pause_non_leader_primary=True,
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    _app = subordinate.split('/')[0]
-                    if _app in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
-                        logging.info("Skipping pausing {} - blacklisted"
-                                     .format(subordinate))
-                    else:
-                        logging.info("Pausing {}".format(subordinate))
-                        model.run_action(
-                            subordinate, "pause", action_params={})
+                    pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
             logging.info("Pausing {}".format(unit))
             model.run_action(unit, "pause", action_params={})
@@ -491,20 +465,12 @@ async def async_series_upgrade_application(
             leader = unit
         else:
             non_leaders.append(unit)
-
     # Pause the non-leaders
     for unit in non_leaders:
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    _app = subordinate.split('/')[0]
-                    if _app in SUBORDINATE_PAUSE_RESUME_BLACKLIST:
-                        logging.info("Skipping pausing {} - blacklisted"
-                                     .format(subordinate))
-                    else:
-                        logging.info("Pausing {}".format(subordinate))
-                        await model.async_run_action(
-                            subordinate, "pause", action_params={})
+                    await async_pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
             logging.info("Pausing {}".format(unit))
             await model.async_run_action(unit, "pause", action_params={})
@@ -970,3 +936,20 @@ async def async_do_release_upgrade(unit_name):
         'DEBIAN_FRONTEND=noninteractive '
         'do-release-upgrade -f DistUpgradeViewNonInteractive',
         raise_exceptions=True)
+
+
+async def async_pause_helper(_type, unit):
+    """Pause helper to ensure that the log happens nearer to the action.
+
+    :param _type: Type of unit (subordinate/leader), used for logging only
+    :param unit: Unit to pause
+    """
+    logging.info("Pausing ({}) {}".format(_type, unit))
+    if "pause" not in model.get_actions(unit.split('/')[0]):
+        logging.info("Skipping pausing {} - no pause action"
+                     .format(unit))
+        return
+    await model.async_run_action(unit, "pause", action_params={})
+    logging.info("Finished Pausing ({}) {}".format(_type, unit))
+
+pause_helper = sync_wrapper(async_pause_helper)

--- a/zaza/openstack/utilities/series_upgrade.py
+++ b/zaza/openstack/utilities/series_upgrade.py
@@ -163,8 +163,7 @@ def series_upgrade_non_leaders_first(
                 for subordinate in status["units"][unit]["subordinates"]:
                     pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
-            logging.info("Pausing {}".format(unit))
-            model.run_action(unit, "pause", action_params={})
+            pause_helper("leader", unit)
 
     # Series upgrade the non-leaders first
     for unit in non_leaders:
@@ -258,7 +257,7 @@ async def async_series_upgrade_non_leaders_first(
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    await async_pause_helper("subordinate", subordinate)
+                    pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
             logging.info("Pausing {}".format(unit))
             await model.async_run_action(unit, "pause", action_params={})
@@ -358,8 +357,7 @@ def series_upgrade_application(application, pause_non_leader_primary=True,
                 for subordinate in status["units"][unit]["subordinates"]:
                     pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
-            logging.info("Pausing {}".format(unit))
-            model.run_action(unit, "pause", action_params={})
+            pause_helper("leader", unit)
 
     machine = status["units"][leader]["machine"]
     # Series upgrade the leader
@@ -470,10 +468,9 @@ async def async_series_upgrade_application(
         if pause_non_leader_subordinate:
             if status["units"][unit].get("subordinates"):
                 for subordinate in status["units"][unit]["subordinates"]:
-                    await async_pause_helper("subordinate", subordinate)
+                    pause_helper("subordinate", subordinate)
         if pause_non_leader_primary:
-            logging.info("Pausing {}".format(unit))
-            await model.async_run_action(unit, "pause", action_params={})
+            pause_helper("leader", unit)
 
     machine = status["units"][leader]["machine"]
     # Series upgrade the leader
@@ -945,7 +942,10 @@ async def async_pause_helper(_type, unit):
     :param unit: Unit to pause
     """
     logging.info("Pausing ({}) {}".format(_type, unit))
-    if "pause" not in model.get_actions(unit.split('/')[0]):
+    print(model.async_get_application)
+    app = await model.async_get_application(unit.split('/')[0])
+    print(app)
+    if "pause" not in await app.get_actions():
         logging.info("Skipping pausing {} - no pause action"
                      .format(unit))
         return


### PR DESCRIPTION
Update series upgrade automation:
 - Update series upgrade async behavior
 - Automatically determine OpenStack-origin config name
 - Check if units can be paused before pausing them (closes #704)
 - Skip upgrading machines that are already upgrades (closes #705)
 - Add entry point for custom vault unsealing methods.

## Testing
The unit tests are up to date and the changes have been tested on a ussuri-bionic cloud by calling `zaza.openstack.charm_tests.series_upgrade.parallel_tests.test_200_run_series_upgrade`.