### PR TITLE
Pin pyOpenSSL to be compatible with cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ lxml<4.6.3
 pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
-# pyopenssl depends on a newer version of cryptography since 22.1.0
+# pyopenssl depends on a newer version of cryptography since 22.0.0
 # TypeError: deprecated() got an unexpected keyword argument 'name'
 # https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
-pyopenssl<22.1.0
+pyopenssl<22.0.0
 
 boto3<1.25
 PyYAML<=4.2,>=3.0

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,10 @@ install_require = [
     'async_generator',
     'boto3',
 
-    # pyopenssl depends on a newer version of cryptography since 22.1.0
+    # pyopenssl depends on a newer version of cryptography since 22.0.0
     # TypeError: deprecated() got an unexpected keyword argument 'name'
     # https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
-    'pyopenssl<22.1.0',
+    'pyopenssl<22.0.0',
 
     # Newer versions require a Rust compiler to build, see
     # * https://github.com/openstack-charmers/zaza/issues/421


### PR DESCRIPTION
pyOpenSSl has been pinned < 22.1.0 but this allows pyOpenSSL 22.0.0 to be installed that requires cryptograph 35.0+.  Unfortunately, cryptography is pinned < 3.4 which creates a conflict leading to strange openssl errors.

The solution is to pin pyOpenSSL < 22.0.0, which will currently select 21.0.0, and that has a requirement for cryptography 3.3+. This combination will select pyOpenSSL 21.0.0 and cryptography 3.3.2 which are compatible.