### PR TITLE
Migrate from nosetest to pytest

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v1
@@ -19,6 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get install -q --yes libxml2-dev libxslt1-dev
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Lint with tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ async_generator
 pyopenssl<22.1.0
 
 boto3<1.25
-PyYAML<=4.2,>=3.0
+PyYAML<=4.2,>=3.0; python_version < '3.10'
+PyYAML>=5.1; python_version >= '3.10'
 flake8>=2.2.4
 flake8-docstrings
 flake8-per-file-ignores

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,8 @@ flake8-per-file-ignores
 pydocstyle<4.0.0
 coverage<6.0.0  # coverage 6.0+ drops support for py3.5/py2.7
 mock>=1.2
-nose>=1.3.7
+pytest
+pytest-cov
 pbr>=1.8.0,<1.9.0
 simplejson>=2.2.0
 netifaces>=0.10.4

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv = VIRTUAL_ENV={envdir}
 install_command =
   {toxinidir}/pip.sh install {opts} {packages}
 
-commands = nosetests --with-coverage --cover-package=zaza.openstack {posargs} {toxinidir}/unit_tests
+commands = pytest --cov=zaza.openstack {posargs} {toxinidir}/unit_tests
 
 [testenv:py3]
 basepython = python3
@@ -36,6 +36,10 @@ deps = -r{toxinidir}/requirements.txt
 
 [testenv:py3.9]
 basepython = python3.9
+deps = -r{toxinidir}/requirements.txt
+
+[testenv:py3.10]
+basepython = python3.10
 deps = -r{toxinidir}/requirements.txt
 
 [testenv:pep8]


### PR DESCRIPTION
nosetest doesn't support python 3.10 and over the years the python community has been settling on pytest as test runner, this change introduces pytest and adds py3.10 to the gh workflow testing matrix.