### PR TITLE
Drop unrelated Python versions

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/tox.ini
+++ b/tox.ini
@@ -30,18 +30,6 @@ commands = nosetests --with-coverage --cover-package=zaza.openstack {posargs} {t
 basepython = python3
 deps = -r{toxinidir}/requirements.txt
 
-[testenv:py3.5]
-basepython = python3.5
-deps = -r{toxinidir}/requirements.txt
-
-[testenv:py3.6]
-basepython = python3.6
-deps = -r{toxinidir}/requirements.txt
-
-[testenv:py3.7]
-basepython = python3.7
-deps = -r{toxinidir}/requirements.txt
-
 [testenv:py3.8]
 basepython = python3.8
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Python 3.5, 3.6, and 3.7 are no longer needed on this branch.

(cherry picked from commit 0fe0f0167cccc0169e146fde654aa599a01c8555)