### PR TITLE
Retry check of service IP configured

### DIFF
--- a/zaza/openstack/charm_tests/designate_bind/tests.py
+++ b/zaza/openstack/charm_tests/designate_bind/tests.py
@@ -16,6 +16,13 @@
 import logging
 import os
 
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_fixed,
+)
+
 import zaza.model as zaza_model
 import zaza.openstack.charm_tests.test_utils as test_utils
 
@@ -43,8 +50,14 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
         zaza_model.set_application_config(self.APPLICATION, config)
         zaza_model.wait_for_application_states()
 
-        configured_ips = zaza_model.run_on_unit(self.UNIT, "ip addr")
-        self.assertIn(self.VIP, configured_ips["Stdout"])
+        for attempt in Retrying(wait=wait_fixed(2),
+                                retry=retry_if_exception_type(AssertionError),
+                                reraise=True,
+                                stop=stop_after_attempt(10)):
+            with attempt:
+                configured_ips = zaza_model.run_on_unit(self.UNIT,
+                                                        "ip addr")
+                self.assertIn(self.VIP, configured_ips["Stdout"])
 
         logging.info("Removing service IP configuration from %s unit.",
                      self.UNIT)


### PR DESCRIPTION
There are scenarios where the config-changed hook can complete, yet the service IP get configured many seconds after, because a relation-changed hook execution needs to be triggered on the hacluster side of the relation.

This change adds a retry to the check (10 times with a 2 seconds wait time).

This issue was found at the gate https://review.opendev.org/c/openstack/charm-designate-bind/+/861417