### PR TITLE
Revert "Test get-csr with existing CA"

### DIFF
--- a/zaza/openstack/charm_tests/vault/tests.py
+++ b/zaza/openstack/charm_tests/vault/tests.py
@@ -152,9 +152,20 @@ class VaultTest(BaseVaultTest):
         """Run setup for Vault tests."""
         super(VaultTest, cls).setUpClass()
 
-    def update_intermediate_csr(self, force=False):
-        """Get a intermediate csr from vault, sign it and upload."""
-        action = vault_utils.run_get_csr(force=force)
+    def test_csr(self):
+        """Test generating a csr and uploading a signed certificate."""
+        vault_actions = zaza.model.get_actions(
+            'vault')
+        if 'get-csr' not in vault_actions:
+            raise unittest.SkipTest('Action not defined')
+        try:
+            zaza.model.get_application(
+                'keystone')
+        except KeyError:
+            raise unittest.SkipTest('No client to test csr')
+        action = vault_utils.run_charm_authorize(
+            self.vault_creds['root_token'])
+        action = vault_utils.run_get_csr()
 
         intermediate_csr = action.data['results']['output']
         (cakey, cacert) = zaza.openstack.utilities.cert.generate_cert(
@@ -180,29 +191,6 @@ class VaultTest(BaseVaultTest):
             states=test_config.get('target_deploy_status', {}))
 
         vault_utils.validate_ca(cacert)
-
-    def test_csr(self):
-        """Test generating a csr and uploading a signed certificate."""
-        vault_actions = zaza.model.get_actions(
-            'vault')
-        if 'get-csr' not in vault_actions:
-            raise unittest.SkipTest('Action not defined')
-        try:
-            zaza.model.get_application(
-                'keystone')
-        except KeyError:
-            raise unittest.SkipTest('No client to test csr')
-        action = vault_utils.run_charm_authorize(
-            self.vault_creds['root_token'])
-        self.update_intermediate_csr()
-
-        # Now that a valid CA is present the get_csr action should require
-        # a force option.
-        logging.info("Re-issuing get-csr and checking it fails")
-        action = vault_utils.run_get_csr()
-        self.assertEqual(action.status, 'failed')
-        logging.info("Re-issuing get-csr with force=True")
-        self.update_intermediate_csr(force=True)
 
     def test_all_clients_authenticated(self):
         """Check all vault clients are authenticated."""

--- a/zaza/openstack/charm_tests/vault/utils.py
+++ b/zaza/openstack/charm_tests/vault/utils.py
@@ -474,20 +474,18 @@ def run_charm_authorize(token):
         action_params={'token': token})
 
 
-def run_get_csr(force=False):
+def run_get_csr():
     """Retrieve CSR from vault.
 
     Run vault charm action to retrieve CSR from vault.
 
-    :param force: Whether to force the request even if valid CA is present.
-    :type force: bool
     :returns: Action object
     :rtype: juju.action.Action
     """
     return zaza.model.run_action_on_leader(
         'vault',
-        'regenerate-intermediate-ca',
-        action_params={'force': force})
+        'get-csr',
+        action_params={})
 
 
 def run_upload_signed_csr(pem, root_ca, allowed_domains):


### PR DESCRIPTION
The original change that added this action is blocked by tox4 issues and this change had broken vault in the gate. Let's revert it and land it when things have calmed down.

Reverts openstack-charmers/zaza-openstack-tests#974