### PR TITLE
Fix handling of libjuju calls

### DIFF
--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -720,7 +720,11 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
         yaml_load_err = "Status of '{}' could not be loaded as yaml:\n{}"
         status_raw = zaza.model.run_action_on_leader("ovn-central",
                                                      "cluster-status")
-        status_data = status_raw.data["results"]
+        status_data = {}
+        try:
+            status_data = status_raw.results
+        except (AttributeError, KeyError):
+            status_data = status_raw.data.get('results', {})
         # Verify expected items in the action result
         self.assertIn("ovnnb", status_data)
         self.assertIn("ovnsb", status_data)

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -80,16 +80,29 @@ def audit_assertions(action,
     :type expected_failures: List[str]
     :raises: AssertionError if the assertion fails.
     """
+    # Updated status is in action._status
+    # https://github.com/juju/python-libjuju/commit/bfcbc0ba968555e317909972c28101b149854b0c
+    status = None
+    try:
+        status = action._status
+    except (AttributeError, KeyError):
+        status = action.data.get("status")
     if expected_failures is None:
         expected_failures = []
     if expected_to_pass:
-        assert action.data["status"] == "completed", \
+        assert status == "completed", \
             "Security check is expected to pass by default"
     else:
-        assert action.data["status"] == "failed", \
+        assert status == "failed", \
             "Security check is not expected to pass by default"
 
-    results = action.data['results']
+    # https://github.com/juju/python-libjuju/commit/fb837cc2a630bb407cf059dc1871a2cc832cf801
+    results = None
+    try:
+        results = action.results
+    except (AttributeError, KeyError):
+        results = action.data.get('results')
+    assert results is not None
     for key, value in results.items():
         if key in expected_failures:
             assert "FAIL" in value, "Unexpected test pass: {}".format(key)
@@ -964,7 +977,12 @@ class BaseDeferredRestartTest(BaseCharmTest):
             unit.entity_id,
             'show-deferred-events',
             raise_on_failure=True)
-        return yaml.safe_load(action.data['results']['output'])
+        action_result = {}
+        try:
+            action_result = action.results
+        except (AttributeError, KeyError):
+            action_result = action.data.get('results', {})
+        return yaml.safe_load(action_result.get('output'))
 
     def check_show_deferred_events_action_restart(self, test_service,
                                                   restart_reason):

--- a/zaza/openstack/charm_tests/vault/setup.py
+++ b/zaza/openstack/charm_tests/vault/setup.py
@@ -162,7 +162,12 @@ def auto_initialize(cacert=None, validation_application='keystone', wait=True,
     basic_setup(cacert=cacert, unseal_and_authorize=True)
 
     action = vault_utils.run_get_csr()
-    intermediate_csr = action.data['results']['output']
+    action_result = {}
+    try:
+        action_result = action.results
+    except (AttributeError, KeyError):
+        action_result = action.data.get('results', {})
+    intermediate_csr = action_result.get('output')
     (cakey, cacertificate) = zaza.openstack.utilities.cert.generate_cert(
         'DivineAuthority',
         generate_ca=True)

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2160,7 +2160,12 @@ def _get_overcloud_auth_k8s(address=None, model_name=None):
         'get-admin-password',
         action_params={}
     )
-    password = action.data['results']['password']
+    results = None
+    try:
+        results = action.results
+    except (AttributeError, KeyError):
+        results = action.data.get('results')
+    password = results.get('password')
 
     # V3 or later
     logging.info('Using keystone API V3 (or later) for overcloud auth')


### PR DESCRIPTION
python-libjuju 3.x has changes related to
output variables for classes like Actions.
This patch handles those cases.