### PR TITLE
Fix CI [Xena]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ juju_wait
 # https://github.com/pyca/pyopenssl/commit/a145fc3bc6d2e943434beb2f04bbf9b18930296f
 pyopenssl<22.1.0
 
-PyYAML<=4.2,>=3.0
+PyYAML<=4.2,>=3.0; python_version < '3.9'
+PyYAML>=5.1; python_version >= '3.9'
 flake8>=2.2.4
 flake8-docstrings
 flake8-per-file-ignores

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ pyparsing<3.0.0  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
 boto3
-juju!=2.8.3  # blacklist 2.8.3 as it appears to have a connection bug
+# - blacklist 2.8.3 as it appears to have a connection bug
+# - pin juju<3.0.0, libjuju's versioning is now tied to the version of juju controller they support.
+juju!=2.8.3,<3.0.0
 juju_wait
 # pyopenssl depends on a newer version of cryptography since 22.1.0
 # TypeError: deprecated() got an unexpected keyword argument 'name'

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ skip_missing_interpreters = False
 #   https://stackoverflow.com/a/38133283
 requires = pip < 20.3
            virtualenv < 20.0
+           tox < 4.0.0
 # NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
 minversion = 3.2.0
 

--- a/unit_tests/utilities/test_zaza_utilities_series_upgrade.py
+++ b/unit_tests/utilities/test_zaza_utilities_series_upgrade.py
@@ -77,7 +77,7 @@ class TestSeriesUpgrade(ut_utils.BaseTestCase):
             _unit, _machine_num, origin=_origin,
             to_series=_to_series, from_series=_from_series,
             workaround_script=_workaround_script, files=_files)
-        self.block_until_all_units_idle.called_with()
+        self.block_until_all_units_idle.assert_called()
         self.prepare_series_upgrade.assert_called_once_with(
             _machine_num, to_series=_to_series)
         self.wrap_do_release_upgrade.assert_called_once_with(


### PR DESCRIPTION
List of backports:

- Pin tox<4.0.0
- Pin PyYAML
- Replace called_with() with assert_called()
- Pin juju<3.0.0