### PR TITLE
Test the keystone rotate-service-user-password action

### DIFF
--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -203,7 +203,8 @@ class CharmOperationTest(BaseKeystoneTest):
                 '{} is not deployed, so not doing password change'
                 .format(GLANCE_APP))
         # keep the old password to verify it is changed.
-        old_passwd = juju_utils.leader_get(GLANCE_APP, GLANCE_PASSWD_KEY)
+        old_passwd = juju_utils.leader_get(
+            self.application_name, GLANCE_PASSWD_KEY)
 
         # verify that images can be listed.
         glance_client = openstack_utils.get_glance_session_client(
@@ -218,7 +219,8 @@ class CharmOperationTest(BaseKeystoneTest):
         )
 
         # verify that the password has changed
-        new_passwd = juju_utils.leader_get(GLANCE_APP, GLANCE_PASSWD_KEY)
+        new_passwd = juju_utils.leader_get(
+            self.application_name, GLANCE_PASSWD_KEY)
         self.assertNotEqual(old_passwd, new_passwd)
 
         # verify that the images can still be listed.

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -206,7 +206,8 @@ class CharmOperationTest(BaseKeystoneTest):
         old_passwd = juju_utils.leader_get(GLANCE_APP, GLANCE_PASSWD_KEY)
 
         # verify that images can be listed.
-        glance_client = openstack_utils.get_glance_session_client(self.admin_keystone_session)
+        glance_client = openstack_utils.get_glance_session_client(
+            self.admin_keystone_session)
         glance_client.images.list()
 
         # run the action to rotate the password.
@@ -221,7 +222,8 @@ class CharmOperationTest(BaseKeystoneTest):
         self.assertNotEqual(old_passwd, new_passwd)
 
         # verify that the images can still be listed.
-        glance_client = openstack_utils.get_glance_session_client(self.admin_keystone_session)
+        glance_client = openstack_utils.get_glance_session_client(
+            self.admin_keystone_session)
         glance_client.images.list()
 
 

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -197,7 +197,7 @@ class CharmOperationTest(BaseKeystoneTest):
         GLANCE_APP = "glance"
 
         # Only do the test if glance is in the model.
-        applications = juju_utils.sync_deployed(self.model_name)
+        applications = zaza.model.sync_deployed(self.model_name)
         if GLANCE_APP not in applications:
             self.skipTest(
                 '{} is not deployed, so not doing password change'

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -202,7 +202,7 @@ class CharmOperationTest(BaseKeystoneTest):
             conf = zaza.model.file_contents('glance/leader', GLANCE_CONF_FILE)
             config = configparser.ConfigParser()
             config.read_string(conf)
-            return config['image_format']['password'].strip()
+            return config['keystone_authtoken']['password'].strip()
 
         # Only do the test if glance is in the model.
         applications = zaza.model.sync_deployed(self.model_name)

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -237,7 +237,6 @@ class CharmOperationTest(BaseKeystoneTest):
                             new_passwd_conf)
         self.assertEqual(new_passwd_leader_storage, new_passwd_conf)
 
-
         # verify that the images can still be listed.
         glance_client = openstack_utils.get_glance_session_client(
             self.admin_keystone_session)

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -14,6 +14,7 @@
 
 """Encapsulate keystone testing."""
 import collections
+import configparser
 import json
 import logging
 import pprint
@@ -195,6 +196,13 @@ class CharmOperationTest(BaseKeystoneTest):
         """Verify action used to rotate a service user (glance) password."""
         GLANCE_PASSWD_KEY = "glance_passwd"
         GLANCE_APP = "glance"
+        GLANCE_CONF_FILE = '/etc/glance/glance-api.conf'
+
+        def _get_password_from_leader():
+            conf = zaza.model.file_contents('glance/leader', GLANCE_CONF_FILE)
+            config = configparser.ConfigParser()
+            config.read(conf)
+            return config['image_format']['password'].strip()
 
         # Only do the test if glance is in the model.
         applications = zaza.model.sync_deployed(self.model_name)
@@ -203,8 +211,9 @@ class CharmOperationTest(BaseKeystoneTest):
                 '{} is not deployed, so not doing password change'
                 .format(GLANCE_APP))
         # keep the old password to verify it is changed.
-        old_passwd = juju_utils.leader_get(
+        old_passwd_leader_storage = juju_utils.leader_get(
             self.application_name, GLANCE_PASSWD_KEY)
+        old_passwd_conf = _get_password_from_leader()
 
         # verify that images can be listed.
         glance_client = openstack_utils.get_glance_session_client(
@@ -219,9 +228,15 @@ class CharmOperationTest(BaseKeystoneTest):
         )
 
         # verify that the password has changed
-        new_passwd = juju_utils.leader_get(
+        new_passwd_leader_storage = juju_utils.leader_get(
             self.application_name, GLANCE_PASSWD_KEY)
-        self.assertNotEqual(old_passwd, new_passwd)
+        new_passwd_conf = _get_password_from_leader()
+        self.assertNotEqual(old_passwd_leader_storage,
+                            new_passwd_leader_storage)
+        self.assertNotEqual(old_passwd_conf,
+                            new_passwd_conf)
+        self.assertEqual(new_passwd_leader_storage, new_passwd_conf)
+
 
         # verify that the images can still be listed.
         glance_client = openstack_utils.get_glance_session_client(

--- a/zaza/openstack/charm_tests/keystone/tests.py
+++ b/zaza/openstack/charm_tests/keystone/tests.py
@@ -201,7 +201,7 @@ class CharmOperationTest(BaseKeystoneTest):
         def _get_password_from_leader():
             conf = zaza.model.file_contents('glance/leader', GLANCE_CONF_FILE)
             config = configparser.ConfigParser()
-            config.read(conf)
+            config.read_string(conf)
             return config['image_format']['password'].strip()
 
         # Only do the test if glance is in the model.


### PR DESCRIPTION
This test, added as part of the default keystone tests, tests that the service user password can be rotated for the glance application.