### PR TITLE
Skip test_930_scaleback on crmsh-4.4.0-1ubuntu1

### DIFF
--- a/unit_tests/charm_tests/test_utils.py
+++ b/unit_tests/charm_tests/test_utils.py
@@ -185,6 +185,25 @@ class TestBaseCharmTest(ut_utils.BaseTestCase):
 
         self.config_current.assert_called_once_with(None, None)
 
+    @mock.patch('zaza.openstack.utilities.generic.get_pkg_version')
+    def test_skipVersion(self, get_pkg_version):
+        releases = ['4.3.0', '4.0.0']
+
+        @test_utils.skipVersion('hacluster', 'crmsh',
+                                releases=releases,
+                                op='eq',
+                                reason='should not run')
+        def _check_should_not_run():
+            raise Exception('should not run')
+
+        for release in releases:
+            get_pkg_version.return_value = release
+            _check_should_not_run()
+            get_pkg_version.reset_mock()
+
+        get_pkg_version.return_value = '4.4.1'
+        self.assertRaises(Exception, _check_should_not_run)
+
 
 class TestOpenStackBaseTest(ut_utils.BaseTestCase):
 

--- a/zaza/openstack/charm_tests/hacluster/tests.py
+++ b/zaza/openstack/charm_tests/hacluster/tests.py
@@ -87,6 +87,11 @@ class HaclusterScaleBackAndForthTest(HaclusterBaseTest):
         cls._principle_app_name = test_config['principle-app-name']
         cls._hacluster_charm_name = test_config['hacluster-charm-name']
 
+    @test_utils.skipVersion(application='hacluster',
+                            package='crmsh',
+                            releases=['4.4.0-1ubuntu1'],
+                            op='eq',
+                            reason='http://pad.lv/1972730')
     def test_930_scaleback(self):
         """Remove one unit, recalculate quorum and re-add one unit.
 


### PR DESCRIPTION
The crmsh package available in kinetic fails to put a cluster node in maintenance mode, this is part of the scaleback process, more details on the failure available at the related bug.

This change introduces a new decorator skipVersion() that allows to provide a list of package versions with an operation flag on how dpkg should compare the version(s).

The test HaclusterTest.test_930_scaleback() is disabled when running crmsh-4.4.0-1ubuntu1, at the moment this would be kinetic, although if any new package gets released this test will be re-enabled automatically allowing us catch early if the test got fixed or not.

Related-Bug: http://pad.lv/1972730