### PR TITLE
Unpin python-glanceclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_require = [
     'python-designateclient>=1.5,<3.0.0',
     'python-heatclient<2.0.0',
     'python-ironicclient',
-    'python-glanceclient<3.0.0',
+    'python-glanceclient',
     'python-keystoneclient<3.22.0',
     'python-magnumclient',
     'python-manilaclient<2.0.0',


### PR DESCRIPTION
Recent changes in tempest [1][2] requires jsonschema 4.16.0 Without jsonschema 4.16.0, tempest cli commands are not loaded. But there is a conflict with warlock package used by python-glanceclient 2.17.1.

Unpin python-glanceclient to use the latest version further allowing to install latest warlock and jsonschema.

[1] https://review.opendev.org/c/openstack/tempest/+/875264
[2] https://bugs.launchpad.net/tempest/+bug/2008490/comments/3