### PR TITLE
Fix ceph-iscsi tests (zed)

### DIFF
--- a/zaza/openstack/charm_tests/ceph/iscsi/tests.py
+++ b/zaza/openstack/charm_tests/ceph/iscsi/tests.py
@@ -254,9 +254,11 @@ class CephISCSIGatewayTest(test_utils.BaseCharmTest):
         """
         self.create_iscsi_target(test_ctxt)
         self.login_iscsi_target(test_ctxt)
+        self.refresh_partitions(test_ctxt)
         self.check_client_device(test_ctxt, init_client=True)
         self.logout_iscsi_targets(test_ctxt)
         self.login_iscsi_target(test_ctxt)
+        self.refresh_partitions(test_ctxt)
         self.check_client_device(test_ctxt, init_client=False)
         self.refresh_partitions(test_ctxt)
 


### PR DESCRIPTION
Another PR did mostly the same, but this PR makes it more similar to what we have pending for the stable branches.

This PR is being tested in this gerrit patchset:
https://review.opendev.org/c/openstack/charm-ceph-iscsi/+/871317