### PR TITLE
Unblock after pristine deconfiguration

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -413,6 +413,29 @@ class CephTest(test_utils.BaseCharmTest):
 
         zaza_model.wait_for_application_states()
 
+    def test_active_after_pristine_block(self):
+        """Test if we can get back to active state after pristine block.
+
+        Set a non-pristine status, then trigger update-status to see if it
+        clears.
+        """
+        logging.info('Setting Non-pristine status')
+        zaza_model.run_on_leader(
+            "ceph-osd",
+            "status-set blocked 'Non-pristine'"
+        )
+        ceph_osd_states = {
+            'ceph-osd': {
+                'workload-status': 'blocked',
+                'workload-status-message-prefix': 'Non-pristine'
+            }
+        }
+        zaza_model.wait_for_application_states(states=ceph_osd_states)
+        logging.info('Running update-status action')
+        zaza_model.run_on_leader('ceph-osd', 'hooks/update-status')
+        logging.info('Wait for idle/ready status')
+        zaza_model.wait_for_application_states()
+
     def test_pause_and_resume(self):
         """The services can be paused and resumed."""
         logging.info('Checking pause and resume actions...')
@@ -552,7 +575,7 @@ class CephTest(test_utils.BaseCharmTest):
             action_name='remove-disk',
             action_params={
                 'osd-ids': osd_id,
-                'timeout': 5,
+                'timeout': 10,
                 'format': 'json',
                 'purge': is_purge
             }


### PR DESCRIPTION
When a charm has a non-pristine disk deconfigured, it should leave the previously-set blocked state (LP #1988088).