### PR TITLE
Unpin dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 # pin lxml < 4.6.3 for py35 as no wheels exist for 4.6.3 (deprecated platform)
 # This is necessary for Xenial builders
 # BUG: https://github.com/openstack-charmers/zaza-openstack-tests/issues/530
-lxml<4.6.3
-pyparsing<3.0.0  # pin for aodhclient which is held for py35
+lxml<4.6.3; python_version < '3.8'
+lxml; python_version >= '3.8'
+pyparsing<3.0.0; python_version <= '3.5'  # pin for aodhclient which is held for py35
 aiounittest
 async_generator
 # pyopenssl depends on a newer version of cryptography since 22.1.0


### PR DESCRIPTION
- Unpin lxml for python >= 3.8
- Unpin pyparsing for python <= 3.5

Job runners use Focal since https://github.com/openstack-charmers/zosci-config/pull/129

Fixes: #530