### PR TITLE
Use zaza.model.get_unit_public_address()

### DIFF
--- a/zaza/openstack/charm_tests/mysql/test_prometheus_mysql_exporter.py
+++ b/zaza/openstack/charm_tests/mysql/test_prometheus_mysql_exporter.py
@@ -118,7 +118,7 @@ class PrometheusMySQLExporterTest(MySQLBaseTest):
             self.assertEqual(
                 json_mysql_config,
                 {
-                    "host": unit.public_address,
+                    "host": zaza_model.get_unit_public_address(unit),
                     "port": 3306,
                     "user": "prom_exporter"
                 }


### PR DESCRIPTION
Replace the use of "unit.public_address" with
zaza.model.get_unit_public_address().

    AssertionError: {'host': '172.16.0.25', 'port': 3306, 'user': 'prom_exporter'} != {'host': None, 'port': 3306, 'user': 'prom_exporter'}
    - {'host': '172.16.0.25', 'port': 3306, 'user': 'prom_exporter'}
    ?          ^^^^^^^^^^^^^
    + {'host': None, 'port': 3306, 'user': 'prom_exporter'}

Related-Bug: openstack-charmers/zaza#472