### PR TITLE
Add CompareOpenStack class

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_os_versions.py
+++ b/unit_tests/utilities/test_zaza_utilities_os_versions.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unit_tests.utils as ut_utils
+from zaza.openstack.utilities import os_versions
+
+
+class TestOpenStackUtils(ut_utils.BaseTestCase):
+
+    def test_compare_openstack(self):
+        antelope = os_versions.CompareOpenStack('antelope')
+        zed = os_versions.CompareOpenStack('zed')
+        yoga = os_versions.CompareOpenStack('yoga')
+        self.assertGreater(antelope, zed)
+        self.assertLess(zed, antelope)
+        self.assertGreaterEqual(zed, zed)
+        self.assertGreaterEqual(antelope, yoga)
+        self.assertGreaterEqual(zed, yoga)
+
+        self.assertEqual("CompareOpenStack<zed>", repr(zed))

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -38,6 +38,7 @@ import urllib
 
 
 from .os_versions import (
+    CompareOpenStack,
     OPENSTACK_CODENAMES,
     SWIFT_CODENAMES,
     OVN_CODENAMES,
@@ -2116,7 +2117,7 @@ def get_keystone_api_version(model_name=None):
         'keystone',
         'preferred-api-version',
         model_name=model_name)
-    if os_version >= 'queens':
+    if CompareOpenStack(os_version) >= 'queens':
         api_version = 3
     elif api_version is None:
         api_version = 2

--- a/zaza/openstack/utilities/os_versions.py
+++ b/zaza/openstack/utilities/os_versions.py
@@ -365,6 +365,10 @@ class BasicStringComparator(object):
         """Do less than or equals."""
         return not self.__gt__(other)
 
+    def __repr__(self):
+        """Return the representation of CompareOpenStack."""
+        return "%s<%s>" % (self.__class__.__name__, self._list[self.index])
+
     def __str__(self):
         """Give back the item at the index.
 
@@ -390,3 +394,15 @@ class CompareHostReleases(BasicStringComparator):
     """
 
     _list = UBUNTU_RELEASES
+
+
+class CompareOpenStack(BasicStringComparator):
+    """Provide comparisons of OpenStack releases.
+
+    Use in the form of
+
+    if CompareOpenStack(release) > 'yoga':
+        # do something
+    """
+
+    _list = list(OPENSTACK_CODENAMES.values())


### PR DESCRIPTION
The latest OpenStack release is code named "antelope" which produces issues when comparing the versions as strings, this change introduces a new comparison class to address this problem.