### PR TITLE
fix racing condition on cinder and nova controller with L7 checks

### DIFF
--- a/zaza/openstack/charm_tests/nova/tests.py
+++ b/zaza/openstack/charm_tests/nova/tests.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import tempfile
+import tenacity
 import unittest
 import urllib
 from configparser import ConfigParser
@@ -769,6 +770,8 @@ class NovaCloudControllerActionTest(test_utils.OpenStackBaseTest):
     to avoid breaking older version.
     """
 
+    @tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, max=60),
+                    reraise=True, stop=tenacity.stop_after_attempt(4))
     def test_sync_compute_az_action(self):
         """Test sync-compute-availability-zones action."""
         juju_units_az_map = {}

--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -616,6 +616,8 @@ class CinderTests(BasePolicydSpecialization):
         super(CinderTests, cls).setUpClass(application_name="cinder")
         cls.application_name = "cinder"
 
+    @tenacity.retry(wait=tenacity.wait_fixed(1),
+                    reraise=True, stop=tenacity.stop_after_delay(8))
     def get_client_and_attempt_operation(self, ip):
         """Attempt to list the images as a policyd override.
 


### PR DESCRIPTION
[charm-cinder](https://review.opendev.org/c/openstack/charm-cinder/+/874177) and [charm-nova-cloud-controller](https://review.opendev.org/c/openstack/charm-nova-cloud-controller/+/875299) were failing the CI because the L7 checks delay backends as being marked as available which is causing the tests to fail.

This PR should be approved before merging the changes on the respective OpenStack API charms.