### PR TITLE
Bump up http timeout to 2 minutes.

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -138,3 +138,7 @@ insecure_registry = {{ test_registry_prefix }}
 
 [dns]
 nameservers = {{ test_name_server }}
+
+[service-clients]
+# Default is 60s which is not enough for resource constrained environments.
+http_timeout = 120


### PR DESCRIPTION
Tempest clients have a default timeout of 60s which has shown to not be enough for resource constrained environments.