### PR TITLE
Increase tenacity delay for policyd tests

### DIFF
--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -536,7 +536,7 @@ class NeutronApiTests(BasePolicydSpecialization):
     # will fail intermittently unless we gracefully accept this.
     # Issue: openstack-charmers/zaza-openstack-tests#138
     @tenacity.retry(wait=tenacity.wait_fixed(1),
-                    reraise=True, stop=tenacity.stop_after_delay(8))
+                    reraise=True, stop=tenacity.stop_after_delay(16))
     def get_client_and_attempt_operation(self, ip):
         """Attempt to list the networks as a policyd override.
 
@@ -581,7 +581,7 @@ class GlanceTests(BasePolicydSpecialization):
     # accept this.
     # Issue: openstack-charmers/zaza-openstack-tests#578
     @tenacity.retry(wait=tenacity.wait_fixed(1),
-                    reraise=True, stop=tenacity.stop_after_delay(8))
+                    reraise=True, stop=tenacity.stop_after_delay(16))
     def get_client_and_attempt_operation(self, ip):
         """Attempt to list the images as a policyd override.
 
@@ -617,7 +617,7 @@ class CinderTests(BasePolicydSpecialization):
         cls.application_name = "cinder"
 
     @tenacity.retry(wait=tenacity.wait_fixed(1),
-                    reraise=True, stop=tenacity.stop_after_delay(8))
+                    reraise=True, stop=tenacity.stop_after_delay(16))
     def get_client_and_attempt_operation(self, ip):
         """Attempt to list the images as a policyd override.
 


### PR DESCRIPTION
Double the tenacity stop_after_delay for the
get_client_and_attempt_operation methods. This fixes the "Unable to establish connection" test failures seen in: https://review.opendev.org/c/openstack/charm-cinder-ceph/+/878958

cherry-pick from db41710d704918c2e2b2a778ee754198344b7b43 which was PR#1039