### PR TITLE
(s/antelope) Change skipVersion decorator to a function

### DIFF
--- a/unit_tests/charm_tests/test_utils.py
+++ b/unit_tests/charm_tests/test_utils.py
@@ -186,18 +186,18 @@ class TestBaseCharmTest(ut_utils.BaseTestCase):
         self.config_current.assert_called_once_with(None, None)
 
     @mock.patch('zaza.openstack.utilities.generic.get_pkg_version')
-    def test_skipVersion(self, get_pkg_version):
-        releases = ['4.3.0', '4.0.0']
+    def test_package_version_matches(self, get_pkg_version):
+        versions = ['4.3.0', '4.0.0']
 
-        @test_utils.skipVersion('hacluster', 'crmsh',
-                                releases=releases,
-                                op='eq',
-                                reason='should not run')
         def _check_should_not_run():
+            package_version = test_utils.package_version_matches(
+                'hacluster', 'crmsh', versions=versions, op='eq')
+            if package_version and package_version != '4.4.1':
+                return
             raise Exception('should not run')
 
-        for release in releases:
-            get_pkg_version.return_value = release
+        for version in versions:
+            get_pkg_version.return_value = version
             _check_should_not_run()
             get_pkg_version.reset_mock()
 

--- a/zaza/openstack/charm_tests/hacluster/tests.py
+++ b/zaza/openstack/charm_tests/hacluster/tests.py
@@ -86,12 +86,9 @@ class HaclusterScaleBackAndForthTest(HaclusterBaseTest):
         test_config = cls.test_config['tests_options']['hacluster']
         cls._principle_app_name = test_config['principle-app-name']
         cls._hacluster_charm_name = test_config['hacluster-charm-name']
+        cls._hacluster_app_name = ("{}-{}".format(
+            cls._principle_app_name, cls._hacluster_charm_name))
 
-    @test_utils.skipVersion(application='hacluster',
-                            package='crmsh',
-                            releases=['4.4.0-1ubuntu1'],
-                            op='eq',
-                            reason='http://pad.lv/1972730')
     def test_930_scaleback(self):
         """Remove one unit, recalculate quorum and re-add one unit.
 
@@ -101,6 +98,16 @@ class HaclusterScaleBackAndForthTest(HaclusterBaseTest):
         considers having 3 nodes online out of 4, instead of just 3 out of 3.
         This test covers this scenario.
         """
+        package = 'crmsh'
+        package_version = test_utils.package_version_matches(
+            self._hacluster_app_name, package=package,
+            versions=['4.4.0-1ubuntu1'], op='eq')
+        if package_version:
+            logging.warning("Skipping test on application %s (%s:%s), "
+                            "reason: http://pad.lv/1972730",
+                            self._hacluster_app_name, package,
+                            package_version)
+            return
         principle_units = sorted(zaza.model.get_status().applications[
             self._principle_app_name]['units'].keys())
         self.assertEqual(len(principle_units), 3)


### PR DESCRIPTION
The skipVersion decorator was proving to be tricky to use because it took an application name which we didn't want to hard-code, since it is in hacluster/tests.py. One alternative was to pass a charm name instead of application name, but if there were mutiple hacluster applications in the model (e.g. keystone-hacluster and nova-hacluster) we would have to pick just one to test the package version on. After further discussion we decided to change the decorator to a function so that we could use existing class variables to generate the desired hacluster application name.

cherry-pick 95fcad2a0a5c9b4960e8ab5e920729cd49c44aa3 From PR#1037