### PR TITLE
Switch from Quagga to FRR

### DIFF
--- a/zaza/openstack/charm_tests/dragent/configure.py
+++ b/zaza/openstack/charm_tests/dragent/configure.py
@@ -28,7 +28,7 @@ from zaza.openstack.utilities import (
     openstack as openstack_utils,
 )
 
-DEFAULT_PEER_APPLICATION_NAME = "quagga"
+DEFAULT_PEER_APPLICATION_NAME = "osci-frr"
 
 # The overcloud network configuration settings are declared.
 # These are the network configuration settings under test.

--- a/zaza/openstack/charm_tests/dragent/test.py
+++ b/zaza/openstack/charm_tests/dragent/test.py
@@ -29,7 +29,7 @@ from zaza.openstack.utilities import (
 )
 
 
-def test_bgp_routes(peer_application_name="quagga", keystone_session=None):
+def test_bgp_routes(peer_application_name="osci-frr", keystone_session=None):
     """Test BGP routes.
 
     :param peer_application_name: String name of BGP peer application
@@ -90,8 +90,8 @@ def run_from_cli():
     cli_utils.setup_logging()
     parser = argparse.ArgumentParser()
     parser.add_argument("--peer-application", "-a",
-                        help="BGP Peer application name. Default: quagga",
-                        default="quagga")
+                        help="BGP Peer application name. Default: osci-frr",
+                        default="osci-frr")
     options = parser.parse_args()
 
     peer_application_name = cli_utils.parse_arg(options,

--- a/zaza/openstack/charm_tests/dragent/tests.py
+++ b/zaza/openstack/charm_tests/dragent/tests.py
@@ -25,7 +25,7 @@ from zaza.openstack.charm_tests.dragent import test
 class DRAgentTest(unittest.TestCase):
     """Class to encapsulate BPG tests."""
 
-    BGP_PEER_APPLICATION = 'quagga'
+    BGP_PEER_APPLICATION = 'osci-frr'
 
     @classmethod
     def setUpClass(cls):

--- a/zaza/openstack/charm_tests/quagga/__init__.py
+++ b/zaza/openstack/charm_tests/quagga/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Collection of code for testing quagga charm."""
+"""Collection of code for testing osci-frr charm."""

--- a/zaza/openstack/charm_tests/quagga/tests.py
+++ b/zaza/openstack/charm_tests/quagga/tests.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Encapsulating `quagga` testing."""
+"""Encapsulating `FRR` testing."""
 
 import logging
 import re
@@ -23,13 +23,13 @@ import unittest
 import zaza
 
 
-class QuaggaTest(unittest.TestCase):
-    """Class for `quagga` tests."""
+class FrrTest(unittest.TestCase):
+    """Class for `FRR` tests."""
 
     @classmethod
     def setUpClass(cls):
-        """Run class setup for `quagga` tests."""
-        super(QuaggaTest, cls).setUpClass()
+        """Run class setup for `FRR` tests."""
+        super(FrrTest, cls).setUpClass()
 
     def test_bgp_peer_datapath(self):
         """Get peers from BGP neighbour list and ping them."""

--- a/zaza/openstack/configure/bgp_speaker.py
+++ b/zaza/openstack/configure/bgp_speaker.py
@@ -108,8 +108,8 @@ def run_from_cli():
     cli_utils.setup_logging()
     parser = argparse.ArgumentParser()
     parser.add_argument("--peer-application", "-a",
-                        help="BGP peer application name. Default: quagga",
-                        default="quagga")
+                        help="BGP peer application name. Default: osci-frr",
+                        default="osci-frr")
 
     options = parser.parse_args()
     peer_application_name = cli_utils.parse_arg(options,

--- a/zaza/openstack/configure/network.py
+++ b/zaza/openstack/configure/network.py
@@ -167,7 +167,7 @@ def setup_sdn(network_config, keystone_session=None):
         project_id,
         shared=False,
         network_type=network_config["network_type"],
-        net_name=network_config["project_net_name"])
+        net_name=network_config.get("project_net_name", "private"))
     project_subnet = openstack_utils.create_project_subnet(
         neutron_client,
         project_id,
@@ -175,7 +175,8 @@ def setup_sdn(network_config, keystone_session=None):
         network_config.get("private_net_cidr"),
         subnetpool=subnetpool,
         ip_version=ip_version,
-        subnet_name=network_config["project_subnet_name"])
+        subnet_name=network_config.get("project_subnet_name",
+                                       "private_subnet"))
     openstack_utils.update_subnet_dns(
         neutron_client,
         project_subnet,

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1603,7 +1603,7 @@ def add_network_to_bgp_speaker(neutron_client, bgp_speaker, network_name):
         logging.warning('{} network already advertised.'.format(network_name))
 
 
-def create_bgp_peer(neutron_client, peer_application_name='quagga',
+def create_bgp_peer(neutron_client, peer_application_name='osci-frr',
                     remote_as=10000, auth_type='none'):
     """Create BGP peer.
 


### PR DESCRIPTION
A charm that uses FRR instead of Quagga is now published under: https://charmhub.io/osci-frr

For our purposes FRR is a drop-in replacement of Quagga but the point of a change is to remove Quagga references for clarity.