### PR TITLE
Improve logging of _resource_removed()

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2490,8 +2490,14 @@ def _resource_removed(resource, resource_id, msg="resource"):
     :raises: AssertionError
     """
     matching = [r for r in resource.list() if r.id == resource_id]
-    logging.debug("{}: resource {} still present".format(msg, resource_id))
-    assert len(matching) == 0
+    for r in matching:
+        # Info level used, because the gate logs at that level, and if anything
+        # gets logged here it means the next assert will fail and this
+        # information will be needed for troubleshooting.
+        logging.info(r.to_dict())
+
+    msg = "{}: resource {} still present".format(msg, resource_id)
+    assert len(matching) == 0, msg
 
 
 def resource_removed(resource,


### PR DESCRIPTION
On failures there is no information of the state of the objects that couldn't be removed, maybe there are on their way to be removed and this is a failure visible on slow clouds and not an actual issue, this will help with troubleshooting.

(cherry picked from commit b453a850139f6e92af8dc3cf99aafca4ba5e38f4)