### PR TITLE
Retry octavia get_lb_providers

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -316,6 +316,11 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         return resp
 
     @staticmethod
+    @tenacity.retry(
+        retry=tenacity.retry_if_exception_type(keystone_exceptions.http.
+                                               NotFound),
+        wait=tenacity.wait_fixed(5), reraise=True,
+        stop=tenacity.stop_after_delay(300))
     def get_lb_providers(octavia_client):
         """Retrieve loadbalancer providers.
 


### PR DESCRIPTION
The octavia tests can sometimes fail when calling
get_lb_providers if they have not been setup yet.
This adds a retry if keystoneauth1.exceptions.http.NotFound is raised.