### PR TITLE
Retry http request on URLError

### DIFF
--- a/zaza/openstack/charm_tests/openstack_dashboard/tests.py
+++ b/zaza/openstack/charm_tests/openstack_dashboard/tests.py
@@ -146,10 +146,13 @@ def _login(dashboard_url, domain, username, password, cafile=None):
 # NOTE(ajkavanagh): it seems that apache2 doesn't start quickly enough
 # for the test, and so it gets reset errors; repeat until either that
 # stops or there is a failure
-@tenacity.retry(wait=tenacity.wait_exponential(multiplier=1, min=5, max=10),
-                retry=tenacity.retry_if_exception_type(
-                    http.client.RemoteDisconnected),
-                reraise=True)
+@tenacity.retry(
+    wait=tenacity.wait_exponential(multiplier=1, min=5, max=10),
+    retry=(
+        tenacity.retry_if_exception_type(http.client.RemoteDisconnected) |
+        tenacity.retry_if_exception_type(urllib.error.URLError)
+    ),
+    reraise=True)
 def _do_request(request, cafile=None):
     """Open a webpage via urlopen.
 


### PR DESCRIPTION
Retry HTTP requests made to Horizon when a URLError exception is raised to consider cases where the endpoint is being (re)configured.

Error found in the gate:

      File "[...]/charm_tests/openstack_dashboard/tests.py", line 162, in _do_request
        return urllib.request.urlopen(request, cafile=cafile)
      File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
        return opener.open(url, data, timeout)
      File "/usr/lib/python3.8/urllib/request.py", line 525, in open
        response = self._open(req, data)
      File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
        result = self._call_chain(self.handle_open, protocol, protocol +
      File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
        result = func(*args)
      File "/usr/lib/python3.8/urllib/request.py", line 1397, in https_open
        return self.do_open(http.client.HTTPSConnection, req,
      File "/usr/lib/python3.8/urllib/request.py", line 1357, in do_open
        raise URLError(err)
    urllib.error.URLError: <urlopen error EOF occurred in violation of protocol (_ssl.c:1131)>