### PR TITLE
Prevent kerberos setup conflicts

### DIFF
--- a/zaza/openstack/charm_tests/kerberos/setup.py
+++ b/zaza/openstack/charm_tests/kerberos/setup.py
@@ -18,6 +18,7 @@ import logging
 import tempfile
 import tenacity
 from keystoneauth1.exceptions.connection import ConnectFailure
+from keystoneauth1.exceptions.http import Conflict
 
 import zaza.model
 from zaza.openstack.utilities import openstack as openstack_utils
@@ -143,21 +144,34 @@ def openstack_setup_kerberos():
     keystone_session = openstack_utils.get_overcloud_keystone_session()
     keystone_client = openstack_utils.get_keystone_session_client(
         keystone_session)
+
     logging.info('Creating domain, project and user for Kerberos tests.')
-    domain = keystone_client.domains.create(kerberos_domain,
-                                            description='Kerberos Domain',
-                                            enabled=True)
-    project = keystone_client.projects.create(kerberos_project,
-                                              domain,
-                                              description='Test project',
-                                              enabled=True)
-    demo_user = keystone_client.users.create(kerberos_user,
-                                             domain=domain,
-                                             project=project,
-                                             password=kerberos_password,
-                                             email='demo@demo.com',
-                                             description='Demo User',
-                                             enabled=True)
+    try:
+        domain = keystone_client.domains.create(kerberos_domain,
+                                                description='Kerberos Domain',
+                                                enabled=True)
+    except Conflict:
+        domain = keystone_client.domains.find(name=kerberos_domain)
+
+    try:
+        project = keystone_client.projects.create(kerberos_project,
+                                                  domain,
+                                                  description='Test project',
+                                                  enabled=True)
+    except Conflict:
+        project = keystone_client.projects.find(name=kerberos_project)
+
+    try:
+        demo_user = keystone_client.users.create(kerberos_user,
+                                                 domain=domain,
+                                                 project=project,
+                                                 password=kerberos_password,
+                                                 email='demo@demo.com',
+                                                 description='Demo User',
+                                                 enabled=True)
+    except Conflict:
+        demo_user = keystone_client.users.find(name=kerberos_user)
+
     admin_role = keystone_client.roles.find(name=role)
     keystone_client.roles.grant(
         admin_role,


### PR DESCRIPTION
This patch ensures kerberos setup does not create duplicate domains, projects, or users. Duplicate domains were seen to be caused when the tenacity decorator ran the function multiple times.

Fixes #1094