### PR TITLE
Pin zaza to stable/zed in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ paramiko
 # Documentation requirements
 sphinx
 sphinxcontrib-asyncio
-git+https://github.com/openstack-charmers/zaza#egg=zaza
+git+https://github.com/openstack-charmers/zaza@stable/zed#egg=zaza
 
 # Newer versions require a Rust compiler to build, see
 # * https://github.com/openstack-charmers/zaza/issues/421


### PR DESCRIPTION
This only really affects unit testing, but it ought to be stable/zed to
match the branch.
