### PR TITLE
[stable/yoga] Fix pep8 error in ceilometer

### DIFF
--- a/zaza/openstack/charm_tests/ceilometer/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer/tests.py
@@ -126,7 +126,7 @@ class CeilometerTest(test_utils.OpenStackBaseTest):
         current_value = openstack_utils.get_application_config_option(
             self.application_name, config_name
         )
-        assert type(current_value) == bool
+        assert type(current_value) is bool
         new_value = not current_value
 
         # Convert bool to str


### PR DESCRIPTION
Fix below pep8 error message

zaza/openstack/charm_tests/ceilometer/tests.py:129:16: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`

(cherry-picked from f76b226ca40dc9aa3ee900e8158269240feb9c15)

(cherry picked from commit 7078ec65c9b1e9033a2afc8df26130f956cd08fb) (cherry picked from commit 82eaa9708c14275b4e6b3e04f803ffd64a9773b3)