### PR TITLE
Change order of operations in test_manila_share()

### DIFF
--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -391,16 +391,15 @@ packages:
                 fip_1, ssh_user_name, privkey, share_path)
             self._validate_testing_file_from_instance(
                 fip_1, ssh_user_name, privkey)
-            #  Read the previous testing file from instance #1
-            self._mount_share_on_instance(
-                fip_2, ssh_user_name, privkey, share_path)
-            # Reset the test!
+            # Reset the test file
             self._clear_testing_file_on_instance(
                 fip_1, ssh_user_name, privkey
             )
-            # Write a testing file on instance #1
+            # (Re)write a test file on instance #1
             self._write_testing_file_on_instance(
                 fip_1, ssh_user_name, privkey)
             # Validate the testing file from instance #2
+            self._mount_share_on_instance(
+                fip_2, ssh_user_name, privkey, share_path)
             self._validate_testing_file_from_instance(
                 fip_2, ssh_user_name, privkey)


### PR DESCRIPTION
The existing order of operations after restarting the share is:

 1. mount share on ins-1
 2. validate the test file on ins-1
 3. mount share on ins-2
 4. clear the test file using 'rm' on ins-1
 5. write the test file on ins-1
 6. read the test file on ins-2

The issue is that step 4. can result in a stale file handle on ins-2
which takes an unspecified amount of time to clear.  Mounting the share
on ins-2 after the file is re-written does however work without a stale
file handle.  The new order is:

 1. mount share on ins-1
 2. validate the test file on ins-1
 3. clear the test file using 'rm' on ins-1
 4. write the test file on ins-1
 5. mount share on ins-2
 6. read the test file on ins-2

Closes-Bug: #1107
