### PR TITLE
Retry on ContentTooShortError [Ussuri backport]

### DIFF
--- a/zaza/openstack/charm_tests/ceilometer/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer/tests.py
@@ -126,7 +126,7 @@ class CeilometerTest(test_utils.OpenStackBaseTest):
         current_value = openstack_utils.get_application_config_option(
             self.application_name, config_name
         )
-        assert type(current_value) == bool
+        self.assertIsInstance(current_value, bool)
         new_value = not current_value
 
         # Convert bool to str

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2241,6 +2241,12 @@ def find_ubuntu_image(release, arch):
     return UBUNTU_IMAGE_URLS[release].format(release=release, arch=arch)
 
 
+@tenacity.retry(
+    wait=tenacity.wait_fixed(2),
+    stop=tenacity.stop_after_attempt(10),
+    reraise=True,
+    retry=tenacity.retry_if_exception_type(urllib.error.ContentTooShortError),
+)
 def download_image(image_url, target_file):
     """Download the image from the given url to the specified file.
 


### PR DESCRIPTION
This patch makes the download_image() to retry automatically on ContentTooShortError exception, this is an issue that has been seen on the gate, see [0].

[0] https://openstack-ci-reports.ubuntu.com/artifacts/3ae/891712/3/check/focal-wallaby-pacemaker-remote-ssl_masakari/3ae840c/job-output.txt

(cherry picked from commit 91c1cc3c339752377d57a2acc0e3c4355448bd1f)