### PR TITLE
Add tempest tests for Octavia k8s

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -24,6 +24,7 @@ import octaviaclient.api.v2.octavia
 import osc_lib.exceptions
 
 import zaza.model
+import zaza.openstack.charm_tests.tempest.tests as tempest_tests
 import zaza.openstack.charm_tests.test_utils as test_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 
@@ -527,3 +528,9 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
 
         # If we get here, it means the tests passed
         self.run_resource_cleanup = True
+
+
+class OctaviaTempestTestK8S(tempest_tests.TempestTestScaleK8SBase):
+    """Test octavia k8s scale out and scale back."""
+
+    application_name = "octavia"

--- a/zaza/openstack/charm_tests/tempest/utils.py
+++ b/zaza/openstack/charm_tests/tempest/utils.py
@@ -26,6 +26,7 @@ from neutronclient.common import exceptions as neutronexceptions
 
 import zaza.model as model
 import zaza.utilities.deployment_env as deployment_env
+import zaza.utilities.juju as zaza_juju_utils
 import zaza.openstack.utilities.juju as juju_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 import zaza.openstack.charm_tests.glance.setup as glance_setup
@@ -179,7 +180,10 @@ def _get_tempest_context(workspace_path, missing_fatal=True):
         ctxt['enabled_services'],
         missing_fatal=missing_fatal)
     _add_auth_config(ctxt)
-    if 'octavia' in ctxt['enabled_services']:
+    if (
+        'octavia' in ctxt['enabled_services'] and
+        not zaza_juju_utils.is_k8s_deployment()
+    ):
         _add_octavia_config(ctxt)
     return ctxt
 


### PR DESCRIPTION
Add tempest tests for Octavia k8s with
scale-in/scale out.
Apply tempest config for octavia only
if it is not a k8s deployment.