### PR TITLE
swift-proxy: wait for model to settle after running action [Antelope backport]

### DIFF
--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -125,6 +125,13 @@ class SwiftProxyTests(test_utils.OpenStackBaseTest):
                            'search-value': self.TEST_SEARCH_TARGET,
                            'weight': self.TEST_WEIGHT_INITIAL})
         self.assertEqual(action.status, "completed")
+        # let everything settle, because after the set-weight action the
+        # swift-storage units need to get run swift-storage-relation-changed to
+        # get the new ring
+        logging.info("Waiting for model to settle.")
+        zaza.model.wait_for_agent_status()
+        zaza.model.block_until_all_units_idle()
+
         self.assertTrue(
             swift_utils.is_ring_synced('swift-proxy', 'object',
                                        self.TEST_EXPECTED_RING_HOSTS))


### PR DESCRIPTION
Let the units run all the hooks before attempting to check if the ring is synced, because the action set-weight triggers the hook swift-storage-relation-changed in the swift-storage units which it's the one in charge of getting the new ring data.

(cherry picked from commit 0ca305f6c85a8a55091007041c2df3767027e73e)