### PR TITLE
Add waiting for endpoints between units scaling

### DIFF
--- a/zaza/openstack/charm_tests/tempest/tests.py
+++ b/zaza/openstack/charm_tests/tempest/tests.py
@@ -17,7 +17,6 @@
 import logging
 import os
 import subprocess
-import tenacity
 
 import zaza
 import zaza.charm_lifecycle.utils
@@ -25,6 +24,7 @@ import zaza.charm_lifecycle.test
 import zaza.openstack.charm_tests.tempest.utils as tempest_utils
 import zaza.charm_lifecycle.utils as lifecycle_utils
 import tempfile
+import tenacity
 
 
 class TempestTestBase():
@@ -183,7 +183,11 @@ class TempestTestScaleK8SBase(TempestTestBase):
         :returns: Status of tempest run
         :rtype: bool
         """
-        tempest_utils.render_tempest_config_keystone_v3(minimal=True)
+        render_tempest_config_keystone_v3 = tenacity.retry(
+            wait=tenacity.wait_fixed(10), stop=tenacity.stop_after_attempt(3)
+        )(tempest_utils.render_tempest_config_keystone_v3)
+        zaza.openstack.charm_tests.keystone.setup.wait_for_all_endpoints()
+        render_tempest_config_keystone_v3(minimal=True)
         if not super().run():
             return False
 
@@ -193,7 +197,8 @@ class TempestTestScaleK8SBase(TempestTestBase):
         zaza.model.block_until_all_units_idle()
         logging.info("Wait for status ready ...")
         zaza.model.wait_for_application_states(states=self.expected_statuses)
-        tempest_utils.render_tempest_config_keystone_v3(minimal=True)
+        zaza.openstack.charm_tests.keystone.setup.wait_for_all_endpoints()
+        render_tempest_config_keystone_v3(minimal=True)
         if not super().run():
             return False
 
@@ -206,7 +211,8 @@ class TempestTestScaleK8SBase(TempestTestBase):
         zaza.model.block_until_all_units_idle()
         logging.info("Wait for status ready ...")
         zaza.model.wait_for_application_states(states=self.expected_statuses)
-        tempest_utils.render_tempest_config_keystone_v3(minimal=True)
+        zaza.openstack.charm_tests.keystone.setup.wait_for_all_endpoints()
+        render_tempest_config_keystone_v3(minimal=True)
         return super().run()
 
 


### PR DESCRIPTION
Traefik might take some time to update its configuration, and switch multiple times between active and maintenance for the duration. Waiting only for tests is not enough. This change introduce a wait for endpoints to be ready.

Moreover, at glance call to setup the image might fail because of this very reason, add a retry on render_tempest_config_keystone_v3.