### PR TITLE
Import explicity keystone setup module

### DIFF
--- a/zaza/openstack/charm_tests/tempest/tests.py
+++ b/zaza/openstack/charm_tests/tempest/tests.py
@@ -21,6 +21,7 @@ import subprocess
 import zaza
 import zaza.charm_lifecycle.utils
 import zaza.charm_lifecycle.test
+import zaza.openstack.charm_tests.keystone.setup
 import zaza.openstack.charm_tests.tempest.utils as tempest_utils
 import zaza.charm_lifecycle.utils as lifecycle_utils
 import tempfile


### PR DESCRIPTION
In gate, 'zaza.openstack.charm_tests.keystone.setup.wait_for_all_endpoints' is not found without the explicit import of the keystone setup module