### PR TITLE
Allow 401s when checking endpoints

### DIFF
--- a/zaza/openstack/charm_tests/keystone/setup.py
+++ b/zaza/openstack/charm_tests/keystone/setup.py
@@ -208,4 +208,9 @@ def wait_for_all_endpoints(interface='public'):
                                                  interface=interface):
             wait_for_url(
                 ep.url,
-                [requests.codes.ok, requests.codes.multiple_choices])
+                # Heat cloudformation and orchestration return 400 and 401
+                [
+                    requests.codes.ok,
+                    requests.codes.multiple_choices,
+                    requests.codes.bad_request,
+                    requests.codes.unauthorized])


### PR DESCRIPTION
Some endpoints (heat) return 401s if you try and access them without authenticating. Given the ep has been able to verify whether you are authenticated a 401 is ok for a rudementary health check