### PR TITLE
Add tenacity retries around ring sync check [antelope backport]

### DIFF
--- a/zaza/openstack/charm_tests/swift/tests.py
+++ b/zaza/openstack/charm_tests/swift/tests.py
@@ -132,9 +132,15 @@ class SwiftProxyTests(test_utils.OpenStackBaseTest):
         zaza.model.wait_for_agent_status()
         zaza.model.block_until_all_units_idle()
 
-        self.assertTrue(
-            swift_utils.is_ring_synced('swift-proxy', 'object',
-                                       self.TEST_EXPECTED_RING_HOSTS))
+        for attempt in tenacity.Retrying(
+                wait=tenacity.wait_fixed(2),
+                retry=tenacity.retry_if_exception_type(AssertionError),
+                reraise=True,
+                stop=tenacity.stop_after_attempt(10)):
+            with attempt:
+                self.assertTrue(
+                    swift_utils.is_ring_synced('swift-proxy', 'object',
+                                               self.TEST_EXPECTED_RING_HOSTS))
 
     def test_905_remove_device_action_and_validate_rebalance(self):
         """Remove device from object ring."""


### PR DESCRIPTION
This fixes a race when checking if object ring is synced.

(cherry picked from commit 0598ecfc9bebe1fe7264185d6e0027a926e1bad1)