### PR TITLE
tempest: Add serial config

### DIFF
--- a/zaza/openstack/charm_tests/tempest/tests.py
+++ b/zaza/openstack/charm_tests/tempest/tests.py
@@ -81,6 +81,9 @@ class TempestTestBase():
             tempest_options.extend(
                 ['--concurrency',
                  str(config.get('concurrency', min(os.cpu_count(), 4)))])
+            serial = config.get('serial')
+            if serial and serial is True:
+                tempest_options.extend(['--serial'])
             with tempfile.TemporaryDirectory() as tmpdirname:
                 if config.get('include-list'):
                     include_file = os.path.join(tmpdirname, 'include.cfg')


### PR DESCRIPTION
The serial config can be set to True to add the --serial flag to the tempest run. This appears to be useful with the current state of serverstack and fixing tests that fail due to "Bad router request: Router already has a port on subnet <subnet-uuid>."