### PR TITLE
Updates for charm/openstack upgrade testing

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
+++ b/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
@@ -102,6 +102,21 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             actual,
             expected)
 
+    def test_get_charm_upgrade_groups(self):
+        expected = [
+            ('Database Services', []),
+            ('Stateful Services', []),
+            ('Core Identity', []),
+            ('Control Plane', ['cinder']),
+            ('Data Plane', ['nova-compute']),
+            ('sweep_up', ['neutron-openvswitch', 'ntp'])]
+        actual = openstack_upgrade.get_charm_upgrade_groups()
+        pprint.pprint(expected)
+        pprint.pprint(actual)
+        self.assertEqual(
+            actual,
+            expected)
+
     def test_get_series_upgrade_groups(self):
         expected = [
             ('Database Services', ['mydb']),

--- a/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
+++ b/unit_tests/utilities/test_zaza_utilities_upgrade_utils.py
@@ -14,7 +14,6 @@
 
 import copy
 import mock
-import pprint
 
 import unit_tests.utils as ut_utils
 import zaza.openstack.utilities.upgrade_utils as openstack_upgrade
@@ -96,8 +95,6 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             ('Data Plane', ['nova-compute']),
             ('sweep_up', [])]
         actual = openstack_upgrade.get_upgrade_groups()
-        pprint.pprint(expected)
-        pprint.pprint(actual)
         self.assertEqual(
             actual,
             expected)
@@ -111,8 +108,6 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             ('Data Plane', ['nova-compute']),
             ('sweep_up', ['neutron-openvswitch', 'ntp'])]
         actual = openstack_upgrade.get_charm_upgrade_groups()
-        pprint.pprint(expected)
-        pprint.pprint(actual)
         self.assertEqual(
             actual,
             expected)
@@ -126,8 +121,6 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             ('Data Plane', ['nova-compute']),
             ('sweep_up', ['ntp'])]
         actual = openstack_upgrade.get_series_upgrade_groups()
-        pprint.pprint(expected)
-        pprint.pprint(actual)
         self.assertEqual(
             actual,
             expected)
@@ -141,8 +134,6 @@ class TestUpgradeUtils(ut_utils.BaseTestCase):
             ('sweep_up', ['ntp'])]
         actual = openstack_upgrade.get_series_upgrade_groups(
             target_series='focal')
-        pprint.pprint(expected)
-        pprint.pprint(actual)
         self.assertEqual(
             actual,
             expected)

--- a/zaza/openstack/charm_tests/charm_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/charm_upgrade/tests.py
@@ -22,8 +22,8 @@ import unittest
 import zaza.model
 from zaza.openstack.utilities import (
     cli as cli_utils,
-    os_versions as os_versions,
-    upgrade_utils as upgrade_utils,
+    os_versions,
+    upgrade_utils,
 )
 
 

--- a/zaza/openstack/charm_tests/openstack_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/openstack_upgrade/tests.py
@@ -43,7 +43,7 @@ class OpenStackUpgradeVMLaunchBase(unittest.TestCase):
     nova-cloud-controller, nova-compute, neutron-gateway, neutron-api and
     neutron-openvswitch.
 
-    This class should be used as a base class to the upgrade 'test'.
+    This class can be used as a base class to the upgrade 'test'.
     """
 
     @classmethod
@@ -85,21 +85,7 @@ class WaitForMySQL(unittest.TestCase):
         logging.info("Done .. all seems well.")
 
 
-class OpenStackUpgradeTestsFocalUssuri(OpenStackUpgradeVMLaunchBase):
-    """Upgrade OpenStack from distro -> cloud:focal-victoria."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Run setup for OpenStack Upgrades."""
-        super().setUpClass()
-        cli_utils.setup_logging()
-
-    def test_200_run_openstack_upgrade(self):
-        """Run openstack upgrade, but work out what to do."""
-        openstack_upgrade.run_upgrade_tests("cloud:focal-victoria")
-
-
-class OpenStackUpgradeTestsByOption(OpenStackUpgradeVMLaunchBase):
+class OpenStackUpgradeTestsByOption(unittest.TestCase):
     """A Principal Class to encapsulate OpenStack Upgrade Tests.
 
     A generic Test class that uses the options in the tests.yaml to use a charm
@@ -121,12 +107,7 @@ class OpenStackUpgradeTestsByOption(OpenStackUpgradeVMLaunchBase):
         cli_utils.setup_logging()
 
     def test_200_run_openstack_upgrade(self):
-        """Run openstack upgrade, but work out what to do.
-
-        TODO: This is really inefficient at the moment, and doesn't (yet)
-        determine which ubuntu version to work from.  Don't use until we can
-        make it better.
-        """
+        """Run openstack upgrade, but work out what to do."""
         # get the tests_options / openstack-upgrade.detect-using-charm so that
         # the ubuntu version and OpenStack version can be detected.
         try:

--- a/zaza/openstack/utilities/upgrade_utils.py
+++ b/zaza/openstack/utilities/upgrade_utils.py
@@ -50,9 +50,37 @@ SERVICE_GROUPS = (
         'swift-proxy', 'swift-storage']))
 
 UPGRADE_EXCLUDE_LIST = [
-    'rabbitmq-server',
+    'ceph-fs',
+    'ceph-mon',
+    'ceph-osd',
+    'memcached',
+    'mysql-innodb-cluster',
+    'ovn-central',
+    'ovn-chassis',
     'percona-cluster',
+    # glance-simplestreams-sync disabled due to:
+    # https://bugs.launchpad.net/juju/+bug/1951182
     'glance-simplestreams-sync',
+    'percona-cluster',
+    'rabbitmq-server',
+    'vault',
+    'aodh-mysql-router',
+    'barbican-mysql-router',
+    'cinder-mysql-router',
+    'designate-mysql-router',
+    'glance-mysql-router',
+    'gnocchi-mysql-router',
+    'heat-mysql-router',
+    'keystone-mysql-router',
+    'magnum-mysql-router',
+    'manila-ganesha-mysql-router',
+    'manila-mysql-router',
+    'neutron-mysql-router',
+    'nova-mysql-router',
+    'octavia-mysql-router',
+    'placement-mysql-router',
+    'vault-mysql-router',
+    'watcher-mysql-router',
 ]
 
 
@@ -231,7 +259,10 @@ def get_charm_upgrade_groups(model_name=None, extra_filters=None):
     :returns: Dict of group lists keyed on group name.
     :rtype: collections.OrderedDict
     """
-    filters = _apply_extra_filters([], extra_filters)
+    filters = [
+        _filter_openstack_upgrade_list,
+    ]
+    filters = _apply_extra_filters(filters, extra_filters)
     apps_in_model = get_upgrade_candidates(
         model_name=model_name,
         filters=filters)
@@ -306,13 +337,18 @@ def determine_next_openstack_release(release):
 
     The returned value is a tuple of the form: ('2020.1', 'ussuri')
 
-    :param release: the release to use as the base
+    :param release: the release version or codename to use as the base
     :type release: str
     :returns: the release tuple immediately after the current one.
     :rtype: Tuple[str, str]
     :raises: KeyError if the current release doesn't actually exist
     """
-    old_index = list(OPENSTACK_CODENAMES.values()).index(release)
+    version_match = r"[0-9]{4}\.[0-2]"
+    if re.match(version_match, release):
+        releases = list(OPENSTACK_CODENAMES.keys())
+    else:
+        releases = list(OPENSTACK_CODENAMES.values())
+    old_index = releases.index(release)
     new_index = old_index + 1
     return list(OPENSTACK_CODENAMES.items())[new_index]
 


### PR DESCRIPTION
Updates charm upgrades to use channels, tracks, and risks instead of URLs.

Currently these tests only upgrade OpenStack charms and packages. The OVN, ceph, and misc charms and payloads are not upgraded.

Remove instance creation since tempest can be used to verify the cloud.