### PR TITLE
Add test to report installed proposed packages

### DIFF
--- a/zaza/openstack/charm_tests/charm_upgrade/tests.py
+++ b/zaza/openstack/charm_tests/charm_upgrade/tests.py
@@ -52,7 +52,7 @@ class FullCloudCharmUpgradeTest(unittest.TestCase):
                 os_version, os_codename = (
                     upgrade_utils.determine_next_openstack_release(
                         charm_track))
-                if os_versions.CompareOpenStack(os_codename) >= 'zed':
+                if os_versions.CompareOpenStack(os_codename) > 'zed':
                     new_charm_track = os_version
                 else:
                     new_charm_track = os_codename

--- a/zaza/openstack/charm_tests/status/tests.py
+++ b/zaza/openstack/charm_tests/status/tests.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Code for running status tests."""
+
+import logging
+import subprocess
+import unittest
+
+import zaza
+import zaza.openstack.charm_tests.test_utils as test_utils
+
+class ProposedPackageReport(test_utils.OpenStackBaseTest):
+    """Proposed packages report status test class."""
+
+    def test_100_report_proposed_packages(self):
+        """Report proposed packages installed on each unit."""
+
+        machines = []
+        cmd = 'apt list --installed'
+        for application in zaza.model.get_status().applications:
+            for unit in zaza.model.get_units(application):
+                installed = zaza.model.run_on_unit(unit.entity_id, cmd)
+                proposed = []
+                for pkg in installed['Stdout'].split('\n'):
+                    if 'proposed' in pkg:
+                        proposed.append(pkg)
+            logging.info("\n\nProposed packages installed on {}:\n{}".format(
+                unit.entity_id, "\n".join(proposed)))

--- a/zaza/openstack/charm_tests/status/tests.py
+++ b/zaza/openstack/charm_tests/status/tests.py
@@ -15,19 +15,16 @@
 """Code for running status tests."""
 
 import logging
-import subprocess
-import unittest
 
 import zaza
 import zaza.openstack.charm_tests.test_utils as test_utils
+
 
 class ProposedPackageReport(test_utils.OpenStackBaseTest):
     """Proposed packages report status test class."""
 
     def test_100_report_proposed_packages(self):
         """Report proposed packages installed on each unit."""
-
-        machines = []
         cmd = 'apt list --installed'
         for application in zaza.model.get_status().applications:
             for unit in zaza.model.get_units(application):


### PR DESCRIPTION
For SRUs to Ubuntu and the Cloud Archive, bugs need to be updated with testing results and package versions tested. This will enable getting the package versions from charm units in an automated way.