### PR TITLE
Add a retrier-wrap to the nova client for octavia tests

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -85,6 +85,7 @@ from zaza import model
 from zaza.openstack.utilities import (
     exceptions,
     generic as generic_utils,
+    ObjectRetrierWraps,
 )
 import zaza.utilities.networking as network_utils
 
@@ -379,7 +380,8 @@ def get_nova_session_client(session, version=None):
     """
     if not version:
         version = 2
-    return novaclient_client.Client(version, session=session)
+    return ObjectRetrierWraps(
+        novaclient_client.Client(version, session=session))
 
 
 def get_neutron_session_client(session):


### PR DESCRIPTION
The nova service may not be quite ready after vault initialisation for
the basic network configuration, so add a retrier wrapper around the
client for every test to make sure that it retries.
