### PR TITLE
Fix traefik config filename

### DIFF
--- a/zaza/openstack/charm_tests/tempest/tests.py
+++ b/zaza/openstack/charm_tests/tempest/tests.py
@@ -198,7 +198,7 @@ class TempestTestScaleK8SBase(TempestTestBase):
             "determine when traefik has processed all requests")
         units_count = len(zaza.model.get_units(application_name))
         container_cmd = (
-            "cat /opt/traefik/juju/juju_ingress_ingress_*_{}.yaml").format(
+            "cat /opt/traefik/juju/juju_ingress_*_*_{}.yaml").format(
                 application_name)
         container_name = "traefik"
         for unit in zaza.model.get_units("traefik"):


### PR DESCRIPTION
Traefik config file names are of format
juju_ingress_ingress_<id>_<app>.yaml for
ingress interface. However if traefik_route
interface is used, the file name format
is juju_ingress_traefik-route_<id>_<app>.yamlwq

In tempest tests, wait_for_traefik, change the
filename format to support both ingress and
traefik-route interfaces.