### PR TITLE
Remove assertion on number of loadbalancers

### DIFF
--- a/zaza/openstack/charm_tests/tempest/tests.py
+++ b/zaza/openstack/charm_tests/tempest/tests.py
@@ -214,7 +214,6 @@ class TempestTestScaleK8SBase(TempestTestBase):
             loadBalancers = [
                 lb['loadBalancer']
                 for lb in service_config['http']['services'].values()]
-            assert len(loadBalancers) == 1
             unit_count_in_lb = len(loadBalancers[0]['servers'])
             logging.info("Traefik LB server count: {} unit count: {}".format(
                 unit_count_in_lb,


### PR DESCRIPTION
Heat charm when configured with traefik-route
can have multiple loadbalancers (for heat-api
and heat-api-cfn).
So remove the assertion in wait_for_traefik on
number of loadbalancers. Check on number of units
against number of servers should be sufficient.