### PR TITLE
Add tempest confirmation for octavia tests

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -136,6 +136,11 @@ enable_security_groups = true
 test_with_ipv6 = false
 test_server_path = {{ workspace_path }}/test_server.bin
 provider = amphora
+octavia_svc_username = octavia
+member_role = load-balancer_member
+admin_role = Admin
+RBAC_test_type = none
+log_user_roles = False
 {% endif %}
 
 {%- if 'magnum' in enabled_services %}


### PR DESCRIPTION
This sets new tempest config options for octavia, including the setting of log_user_roles=False, which allows tests to avoid the optional list_role_assignments call that was resulting in 403 Forbidden for all octavia tests.