### PR TITLE
Disable changing default_ttl test due to designate bug

### DIFF
--- a/zaza/openstack/charm_tests/designate/tests.py
+++ b/zaza/openstack/charm_tests/designate/tests.py
@@ -134,6 +134,12 @@ class DesignateAPITests(BaseDesignateTest):
 
     def test_300_default_soa_config_options(self):
         """Configure default SOA options."""
+        current_release = openstack_utils.get_os_release()
+        jammy_antelope = openstack_utils.get_os_release('jammy_antelope')
+        if current_release > jammy_antelope:
+            self.skipTest('changing default ttl is currently broken since '
+                          'jammy_bobcat due to LP#2042944')
+
         test_domain = "test_300_example.com."
         DEFAULT_TTL = 60
         alternate_config = {'default-soa-minimum': 600,


### PR DESCRIPTION
In designate bobcat the designate team re-organised the sql-alchemy code
and this has resulted in the bug [1] that means that the default values
for various zone creations are no longer used from the
/etc/designate/designate.conf file.  i.e. the defaults are fixed.

Related-Bug: LP#2042944
