### PR TITLE
Increase tempest ssh timeout

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -111,6 +111,7 @@ img_disk_format = qcow2
 [validation]
 run_validation = true
 image_ssh_user = cirros
+ssh_timeout = 600
 
 [service_available]
 {% for svc in enabled_services -%}


### PR DESCRIPTION
Some of the tests that ssh into instances have been timing out at times. Increase the timeout config for ssh.