### PR TITLE
Add constraints file(s) for testing environments.

### DIFF
--- a/constraints/README.md
+++ b/constraints/README.md
@@ -1,0 +1,19 @@
+# Constraints
+
+This directory holds the pip constraints used by the different testing
+environments used by Charmed OpenStack.
+
+It's worth emphasize that these constraints are used for testing environments,
+that means used in tox.ini files, but never to build charms.
+
+## Naming scheme
+
+The constraints files follow the following nomenclature:
+
+    constraints-$RELEASE.txt
+    
+`$RELEASE` represents the OpenStack release, with the special exception of
+`master` that's used to apply constraints to the `master` and `main` branches.
+
+For example for the case of OpenStack 2023.1 (Antelope), the constraints file
+would be named `constraints-2023.1.txt`.

--- a/constraints/constraints-2024.1.txt
+++ b/constraints/constraints-2024.1.txt
@@ -1,0 +1,9 @@
+# NOTE: this constraints file can be (and will be) consumed by downstream.
+#
+# Known consumers:
+# * zosci-config: job definitions that declare what juju version (snap channel)
+#   is used in tandem with this constraints file to lockdown python-libjuju
+#   version.
+# * zaza-openstack-tests
+#
+juju>=3.1.0,<3.2.0

--- a/constraints/constraints-master.txt
+++ b/constraints/constraints-master.txt
@@ -1,0 +1,9 @@
+# NOTE: this constraints file can be (and will be) consumed by downstream.
+#
+# Known consumers:
+# * zosci-config: job definitions that declare what juju version (snap channel)
+#   is used in tandem with this constraints file to lockdown python-libjuju
+#   version.
+# * zaza-openstack-tests
+#
+juju>=3.1.0,<3.2.0


### PR DESCRIPTION
This change introduces a place to keep the constraints needed to build testing environments. It will be global to all charms under the Charmed OpenStack umbrella, they will be enforced by zosci at the gate.

These constraints are not meant to be used to build charms, for that the tooling that should be used is pip-compile.