### PR TITLE
Set tempdir to a directory under ~/

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,42 +29,43 @@ git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.open
 
 Zaza-openstack-test uses environment variables to configure the tests:
 
-| Env var                      | Description                                               | Default Value                                                                                         |
-|------------------------------|-----------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
-| `FUNCTEST_AMPHORA_LOCATION`  |                                                           | `http://tarballs.openstack.org/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-xenial.qcow2` |
-| `MOJO_LOCAL_DIR`             |                                                           |                                                                                                       |
-| `OS_AUTH_URL`                | Undercloud authentication url                             |                                                                                                       |
-| `OS_PASSWORD`                | Undercloud password                                       |                                                                                                       |
-| `OS_REGION_NAME`             | Undercloud region name                                    |                                                                                                       |
-| `OS_TENANT_NAME`             | Undercloud tenant name                                    |                                                                                                       |
-| `OS_USERNAME`                | Undercloud username                                       |                                                                                                       |
-| `TEST_ARISTA_IMAGE_LOCAL`    |                                                           | `/tmp/arista-cvx-virt-test.qcow2`                                                                     |
-| `TEST_ARISTA_IMAGE_REMOTE`   |                                                           |                                                                                                       |
-| `TEST_BIONIC_IMAGE_NAME`     | Name of bionic image                                      | `bionic`                                                                                              |
-| `TEST_CACERT`                |                                                           |                                                                                                       |
-| `TEST_CAKEY`                 |                                                           |                                                                                                       |
-| `TEST_CERT`                  |                                                           |                                                                                                       |
-| `TEST_CIDR_EXT`              |                                                           |                                                                                                       |
-| `TEST_CIDR_EXT`              |                                                           |                                                                                                       |
-| `TEST_CIRROS_IMAGE_NAME`     | Name of cirros image                                      | `cirros`                                                                                              |
-| `TEST_EXT_NET_SUBNET`        | Name of external subnet                                   | `ext_net_subnet`                                                                                      |
-| `TEST_EXT_NET`               | Name of external network                                  | `ext_net`                                                                                             |
-| `TEST_FIP_RANGE`             | Undercloud fip range                                      |                                                                                                       |
-| `TEST_FOCAL_IMAGE_NAME`      | Name of focal image                                       | `focal`                                                                                               |
-| `TEST_GATEWAY`               | Undercloud gateway                                        |                                                                                                       |
-| `TEST_IRONIC_DEPLOY_INITRD`  |                                                           |                                                                                                       |
-| `TEST_IRONIC_DEPLOY_VMLINUZ` |                                                           |                                                                                                       |
-| `TEST_IRONIC_RAW_BM_IMAGE`   |                                                           |                                                                                                       |
-| `TEST_JAMMY_IMAGE_NAME`      | Name of jammy image                                       | `jammy`                                                                                               |
-| `TEST_KEYPAIR_NAME`          | Name of keypair                                           | `zaza`                                                                                                |
-| `TEST_KEY`                   |                                                           |                                                                                                       |
-| `TEST_MAGNUM_QCOW2_IMAGE_URL`|                                                           |                                                                                                       |
-| `TEST_NAME_SERVER`           | Undercloud name server                                    |                                                                                                       |
-| `TEST_NET_ID`                | Undercloud net id                                         |                                                                                                       |
-| `TEST_NVIDIA_VGPU_HOST_SW`   |                                                           |                                                                                                       |
-| `TEST_PRIVATE_NET_SUBNET`    | Name of private subnet                                    | `private_subnet`                                                                                      |
-| `TEST_PRIVATE_NET`           | Name of private network                                   | `private`                                                                                             |
-| `TEST_PRIVKEY`               | Path to private key corresponding to `TEST_KEYPAIR_NAME`  |                                                                                                       |
-| `TEST_PROVIDER_ROUTER`       | Name of private-external router                           | `provider-router`                                                                                     |
-| `TEST_TRILIO_LICENSE`        |                                                           |                                                                                                       |
-| `TEST_VIP00`                 |                                                           |                                                                                                       |
+| Env var                       | Description                                              | Default Value                                                                                         |
+|-------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| `FUNCTEST_AMPHORA_LOCATION`   |                                                          | `http://tarballs.openstack.org/octavia/test-images/test-only-amphora-x64-haproxy-ubuntu-xenial.qcow2` |
+| `MOJO_LOCAL_DIR`              |                                                          |                                                                                                       |
+| `OS_AUTH_URL`                 | Undercloud authentication url                            |                                                                                                       |
+| `OS_PASSWORD`                 | Undercloud password                                      |                                                                                                       |
+| `OS_REGION_NAME`              | Undercloud region name                                   |                                                                                                       |
+| `OS_TENANT_NAME`              | Undercloud tenant name                                   |                                                                                                       |
+| `OS_USERNAME`                 | Undercloud username                                      |                                                                                                       |
+| `TEST_ARISTA_IMAGE_LOCAL`     |                                                          | `/tmp/arista-cvx-virt-test.qcow2`                                                                     |
+| `TEST_ARISTA_IMAGE_REMOTE`    |                                                          |                                                                                                       |
+| `TEST_BIONIC_IMAGE_NAME`      | Name of bionic image                                     | `bionic`                                                                                              |
+| `TEST_CACERT`                 |                                                          |                                                                                                       |
+| `TEST_CAKEY`                  |                                                          |                                                                                                       |
+| `TEST_CERT`                   |                                                          |                                                                                                       |
+| `TEST_CIDR_EXT`               |                                                          |                                                                                                       |
+| `TEST_CIDR_EXT`               |                                                          |                                                                                                       |
+| `TEST_CIRROS_IMAGE_NAME`      | Name of cirros image                                     | `cirros`                                                                                              |
+| `TEST_EXT_NET_SUBNET`         | Name of external subnet                                  | `ext_net_subnet`                                                                                      |
+| `TEST_EXT_NET`                | Name of external network                                 | `ext_net`                                                                                             |
+| `TEST_FIP_RANGE`              | Undercloud fip range                                     |                                                                                                       |
+| `TEST_FOCAL_IMAGE_NAME`       | Name of focal image                                      | `focal`                                                                                               |
+| `TEST_GATEWAY`                | Undercloud gateway                                       |                                                                                                       |
+| `TEST_IRONIC_DEPLOY_INITRD`   |                                                          |                                                                                                       |
+| `TEST_IRONIC_DEPLOY_VMLINUZ`  |                                                          |                                                                                                       |
+| `TEST_IRONIC_RAW_BM_IMAGE`    |                                                          |                                                                                                       |
+| `TEST_JAMMY_IMAGE_NAME`       | Name of jammy image                                      | `jammy`                                                                                               |
+| `TEST_KEYPAIR_NAME`           | Name of keypair                                          | `zaza`                                                                                                |
+| `TEST_KEY`                    |                                                          |                                                                                                       |
+| `TEST_MAGNUM_QCOW2_IMAGE_URL` |                                                          |                                                                                                       |
+| `TEST_NAME_SERVER`            | Undercloud name server                                   |                                                                                                       |
+| `TEST_NET_ID`                 | Undercloud net id                                        |                                                                                                       |
+| `TEST_NVIDIA_VGPU_HOST_SW`    |                                                          |                                                                                                       |
+| `TEST_PRIVATE_NET_SUBNET`     | Name of private subnet                                   | `private_subnet`                                                                                      |
+| `TEST_PRIVATE_NET`            | Name of private network                                  | `private`                                                                                             |
+| `TEST_PRIVKEY`                | Path to private key corresponding to `TEST_KEYPAIR_NAME` |                                                                                                       |
+| `TEST_PROVIDER_ROUTER`        | Name of private-external router                          | `provider-router`                                                                                     |
+| `TEST_TMPDIR`                 | Path to the e temporary directory used by Python         |                                                                                                       |
+| `TEST_TRILIO_LICENSE`         |                                                          |                                                                                                       |
+| `TEST_VIP00`                  |                                                          |                                                                                                       |

--- a/unit_tests/test_openstack.py
+++ b/unit_tests/test_openstack.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test zaza.openstack module's __init__ code"""
+
+import tempfile
+import unittest
+
+from unittest import mock
+
+import zaza.openstack
+
+
+class TestInit(unittest.TestCase):
+    def setUp(self):
+        self.orig_tmpdir = tempfile.tempdir
+
+    def tearDown(self):
+        # restore original's value of tempdir
+        tempfile.tempdir = self.orig_tmpdir
+
+    @mock.patch('os.environ')
+    @mock.patch('os.mkdir')
+    @mock.patch('os.path.expanduser')
+    @mock.patch('os.path.exists')
+    @mock.patch('os.path.isdir')
+    def test_init(self, isdir, exists, expanduser, mkdir, environ):
+
+        fake_environ = {}
+        environ.get.side_effect = lambda key: fake_environ.get(key)
+        exists.return_value = False
+        isdir.return_value = False
+        expanduser.return_value = '/foo/bar'
+        zaza.openstack._set_tmpdir()
+        expanduser.assert_called_with('~/tmp')
+        mkdir.assert_called_with('/foo/bar', 0o770)
+        self.assertEqual(tempfile.tempdir, '/foo/bar')
+
+        expanduser.reset_mock()
+        mkdir.reset_mock()
+        fake_environ['TEST_TMPDIR'] = '/my/tmpdir'
+        exists.return_value = True
+        isdir.return_value = True
+        zaza.openstack._set_tmpdir()
+        expanduser.assert_not_called()
+        mkdir.assert_not_called()
+
+        self.assertEqual(tempfile.tempdir, '/my/tmpdir')

--- a/zaza/openstack/__init__.py
+++ b/zaza/openstack/__init__.py
@@ -13,3 +13,25 @@
 # limitations under the License.
 
 """OpenStack specific zaza functionality."""
+
+import os
+import tempfile
+
+
+# The temporary directory can't be used when juju's snap is installed in strict
+# mode, so zaza-openstack-tests changes the default tmp directory to the
+# directory referenced by TEST_TMPDIR otherwise a directory is created under
+# the user's home.
+def _set_tmpdir():
+    tmpdir = os.environ.get('TEST_TMPDIR')
+
+    if tmpdir and os.path.exists(tmpdir) and os.path.isdir(tmpdir):
+        tempfile.tempdir = tmpdir
+    else:
+        tmpdir = os.path.expanduser('~/tmp')
+        if not os.path.isdir(tmpdir):
+            os.mkdir(tmpdir, 0o770)
+        tempfile.tempdir = tmpdir
+
+
+_set_tmpdir()


### PR DESCRIPTION
When juju 3.x is used (installed from a snap in strict confinement) the temporary directory of the system (e.g. /tmp) can't be read by 'juju', this is used by zaza-openstack-tests to write testing policy files among other transitory files that are passed to juju's CLI.

This change moves Python's default temporary file to ~/tmp unless overriden by the environment variable TEST_TMPDIR.