### PR TITLE
Pin netaddr<1.0.0

### DIFF
--- a/constraints/constraints-2024.1.txt
+++ b/constraints/constraints-2024.1.txt
@@ -7,3 +7,7 @@
 # * zaza-openstack-tests
 #
 juju>=3.1.0,<3.2.0
+
+# netaddr>=1.0.0 has incompatible changes, see
+# https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0
+netaddr<1.0.0


### PR DESCRIPTION
netaddr>=1.0.0 has incompatible changes, see
https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0

The symptom detected at the gate is:

  TypeError: inet_pton() argument 2 must be str, not MagicMock

More details at
https://review.opendev.org/c/openstack/charm-nova-cloud-controller/+/909613