### PR TITLE
Fix 'NoneType' object has no attribute 'get'

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -238,7 +238,7 @@ async def async_block_until_ca_exists(application_name, ca_cert,
             for unit in units:
                 try:
                     output = await unit.run('cat {}'.format(ca_file))
-                    contents = output.data.get('results').get('Stdout', '')
+                    contents = output.data.get('results', {}).get('Stdout', '')
                     if ca_cert not in contents:
                         break
                 # libjuju throws a generic error for connection failure. So we


### PR DESCRIPTION
There are situations where the action object returned by libjuju may not have the 'results' attribute which leads to using the default value when running ".get('results')" which it's None.

This change sets the default value to an empty dictionary to allow the following ".get('Stdout', '')" succeed.