### PR TITLE
Pin python-libjuju<3.0.0

### DIFF
--- a/constraints/constraints-2024.1.txt
+++ b/constraints/constraints-2024.1.txt
@@ -6,7 +6,7 @@
 #   version.
 # * zaza-openstack-tests
 #
-juju>=3.1.0,<3.2.0
+juju>=2.9.0,<3.0.0
 
 # netaddr>=1.0.0 has incompatible changes, see
 # https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0


### PR DESCRIPTION
The OpenStack Charms gate has proven to be unstable when running juju-3.x, this patch pins libjuju again to 2.9.x until the issues get addressed.

Depends-On: https://github.com/openstack-charmers/zaza/pull/652