### PR TITLE
Implement key rotation tests for OSD units

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1807,7 +1807,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
 
         for attempt in tenacity.Retrying(
             wait=tenacity.wait_exponential(multiplier=2, max=32),
-            reraise=True, stop=tenacity.stop_after_attempt(10),
+            reraise=True, stop=tenacity.stop_after_attempt(20),
             retry=tenacity.retry_if_exception_type(AssertionError)
         ):
             with attempt:

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -28,6 +28,7 @@ import botocore.exceptions
 import urllib3
 
 import tenacity
+import time
 
 import zaza.charm_lifecycle.utils as lifecycle_utils
 import zaza.openstack.charm_tests.test_utils as test_utils
@@ -1802,16 +1803,12 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
         # ceph-mon rotates key | (idle) | remote-unit rotates key | (idle)
         # Between (2) and (3), there's a window where all units are
         # idle, _but_ the key hasn't been rotated in the other unit.
-        # As such, we retry the checks a couple of times instead of
-        # using the `wait_for_application_states` interface.
+        # As such, we sleep for a short time instead of using the
+        # `wait_for_application_states` interface.
 
-        for attempt in tenacity.Retrying(
-            wait=tenacity.wait_exponential(multiplier=2, max=32),
-            reraise=True, stop=tenacity.stop_after_attempt(10),
-            retry=tenacity.retry_if_exception_type(AssertionError)
-        ):
-            new_keys = self._get_all_keys(unit, entity_filter)
-            self.assertNotEqual(old_keys, new_keys)
+        time.sleep(10)
+        new_keys = self._get_all_keys(unit, entity_filter)
+        self.assertNotEqual(old_keys, new_keys)
 
         diff = new_keys - old_keys
         self.assertEqual(len(diff), 1)

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1795,9 +1795,24 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
             action_params={'entity': entity}
         )
         zaza_utils.assertActionRanOK(action_obj)
-        zaza_model.wait_for_application_states(states=self.app_states)
-        new_keys = self._get_all_keys(unit, entity_filter)
-        self.assertNotEqual(old_keys, new_keys)
+        # NOTE(lmlg): There's a nasty race going on here. Essentially,
+        # since this action involves 2 different applications, what
+        # happens is as follows:
+        #          (1)            (2)               (3)              (4)
+        # ceph-mon rotates key | (idle) | remote-unit rotates key | (idle)
+        # Between (2) and (3), there's a window where all units are
+        # idle, _but_ the key hasn't been rotated in the other unit.
+        # As such, we retry the checks a couple of times instead of
+        # using the `wait_for_application_states` interface.
+
+        for attempt in tenacity.Retrying(
+            wait=tenacity.wait_exponential(multiplier=2, max=32),
+            reraise=True, stop=tenacity.stop_after_attempt(10),
+            retry=tenacity.retry_if_exception_type(AssertionError)
+        ):
+            new_keys = self._get_all_keys(unit, entity_filter)
+            self.assertNotEqual(old_keys, new_keys)
+
         diff = new_keys - old_keys
         self.assertEqual(len(diff), 1)
         first = next(iter(diff))

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1802,6 +1802,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
         """Test that rotating the keys actually changes them."""
         unit = 'ceph-mon/0'
         self._check_key_rotation('mgr', unit)
+        self._check_key_rotation('osd.0', unit)
 
         try:
             zaza_model.get_application('ceph-radosgw')


### PR DESCRIPTION
This PR adds OSD tests to the key rotation class for the ceph-mon charm. It will be tested in the following merge requests:
https://review.opendev.org/c/openstack/charm-ceph-mon/+/915925
https://review.opendev.org/c/openstack/charm-ceph-osd/+/915926