### PR TITLE
Implement ceph-fs key rotation tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1841,7 +1841,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
                 # Only wait for ceph-fs, as this model includes 'ubuntu'
                 # units, and those don't play nice with zaza (they don't
                 # set the workload-status-message correctly).
-                self._check_key_rotation(next(iter(fs_svc))[0], unit)
+                self._check_key_rotation(fs_svc, unit)
             else:
                 logging.info('ceph-fs units present, but no MDS service')
         except KeyError:

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1815,9 +1815,9 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
 
         try:
             zaza_model.get_application('ceph-fs')
-            fs_entity = self._get_all_keys(unit, lambda x: x.startswith('mds.'))
-            if fs_entity is not None:
-                self._check_key_rotation(next(iter(fs_entity))[0], unit)
+            fs_svc = self._get_all_keys(unit, lambda x: x.startswith('mds.'))
+            if fs_svc is not None:
+                self._check_key_rotation(next(iter(fs_svc))[0], unit)
             else:
                 logging.info('ceph-fs units present, but no MDS service')
         except KeyError:

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1812,3 +1812,13 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
                 logging.info('ceph-radosgw units present, but no RGW service')
         except KeyError:
             pass
+
+        try:
+            zaza_model.get_application('ceph-fs')
+            fs_entity = self._get_all_keys(unit, lambda x: x.startswith('mds.'))
+            if fs_entity is not None:
+                self._check_key_rotation(next(iter(fs_entity))[0], unit)
+            else:
+                logging.info('ceph-fs units present, but no MDS service')
+        except KeyError:
+            pass

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1812,6 +1812,13 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
             return None
         return next(iter(ret))[0]
 
+    def _get_fs_client(self, unit):
+        ret = self._get_all_keys(unit, lambda x: (x.startswith('mds.') and
+                                                  x != 'mds.ceph-fs'))
+        if not ret:
+            return None
+        return next(iter(ret))[0]
+
     def test_key_rotate(self):
         """Test that rotating the keys actually changes them."""
         unit = 'ceph-mon/0'
@@ -1829,7 +1836,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
 
         try:
             zaza_model.get_application('ceph-fs')
-            fs_svc = self._get_all_keys(unit, lambda x: x.startswith('mds.'))
+            fs_svc = self._get_fs_client(unit)
             if fs_svc is not None:
                 # Only wait for ceph-fs, as this model includes 'ubuntu'
                 # units, and those don't play nice with zaza (they don't

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1770,7 +1770,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
                 ret.add((data[ix - 1], data[ix + 1]))
         return ret
 
-    def _check_key_rotation(self, entity, unit):
+    def _check_key_rotation(self, entity, unit, states=None):
         def entity_filter(name):
             return name.startswith(entity)
 
@@ -1781,7 +1781,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
             action_params={'entity': entity}
         )
         zaza_utils.assertActionRanOK(action_obj)
-        zaza_model.wait_for_application_states()
+        zaza_model.wait_for_application_states(states=states)
         new_keys = self._get_all_keys(unit, entity_filter)
         self.assertNotEqual(old_keys, new_keys)
         diff = new_keys - old_keys
@@ -1817,7 +1817,14 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
             zaza_model.get_application('ceph-fs')
             fs_svc = self._get_all_keys(unit, lambda x: x.startswith('mds.'))
             if fs_svc is not None:
-                self._check_key_rotation(next(iter(fs_svc))[0], unit)
+                ubuntu_states = {
+                    'ubuntu': {
+                        'workload-status': 'active',
+                        'workload-status-message': ''
+                    }
+                }
+                self._check_key_rotation(next(iter(fs_svc))[0], unit,
+                                         ubuntu_states)
             else:
                 logging.info('ceph-fs units present, but no MDS service')
         except KeyError:


### PR DESCRIPTION
This PR implements tests for key rotation in ceph-fs units. It works similarly to how RGW tests do.