### PR TITLE
[DNM] Temporarily disable OSD key rotation tests

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1853,7 +1853,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
         try:
             zaza_model.get_application('ceph-fs')
             fs_svc = self._get_fs_client(unit)
-            if fs_svc is not None:
+            if fs_svc is not None and False:
                 # Only wait for ceph-fs, as this model includes 'ubuntu'
                 # units, and those don't play nice with zaza (they don't
                 # set the workload-status-message correctly).

--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -1838,7 +1838,7 @@ class CephMonKeyRotationTests(test_utils.BaseCharmTest):
     def test_key_rotate(self):
         """Test that rotating the keys actually changes them."""
         unit = 'ceph-mon/0'
-        self._check_key_rotation('osd.0', unit)
+        # self._check_key_rotation('osd.0', unit)
 
         try:
             zaza_model.get_application('ceph-radosgw')


### PR DESCRIPTION
This is just a temporary workaround until we get some merges in. Not meant to be merged, ever.