### PR TITLE
Add caracal to codename maps

### DIFF
--- a/zaza/openstack/utilities/os_versions.py
+++ b/zaza/openstack/utilities/os_versions.py
@@ -42,6 +42,7 @@ UBUNTU_OPENSTACK_RELEASE = OrderedDict([
     ('kinetic', 'zed'),
     ('lunar', 'antelope'),
     ('mantic', 'bobcat'),
+    ('noble', 'caracal'),
 ])
 
 
@@ -71,6 +72,7 @@ OPENSTACK_CODENAMES = OrderedDict([
     ('2022.2', 'zed'),
     ('2023.1', 'antelope'),
     ('2023.2', 'bobcat'),
+    ('2024.1', 'caracal'),
 ])
 
 OPENSTACK_RELEASES_PAIRS = [
@@ -87,6 +89,7 @@ OPENSTACK_RELEASES_PAIRS = [
     'focal_yoga', 'jammy_yoga', 'jammy_zed',
     'kinetic_zed', 'jammy_antelope', 'lunar_antelope',
     'jammy_bobcat', 'mantic_bobcat',
+    'jammy_caracal', 'noble_caracal',
 ]
 
 SWIFT_CODENAMES = OrderedDict([
@@ -320,6 +323,7 @@ UBUNTU_RELEASES = (
     'kinetic',
     'lunar',
     'mantic',
+    'noble',
 )
 
 


### PR DESCRIPTION
jammy-caracal, noble-caracal, 2024.1 and noble are being added to their respective codename maps to allow the testing to recognize caracal.

Fixes:

    Traceback (most recent call last):
      File "/home/ubuntu/src/review.opendev.org/openstack/charm-neutron-api/.tox/func-target/lib/python3.8/site-packages/zaza/openstack/utilities/openstack.py", line 2010, in get_os_release
        index = OPENSTACK_RELEASES_PAIRS.index(release_pair)
    ValueError: 'jammy_caracal' is not in list