### PR TITLE
ceilometer: Bump up timeout

### DIFF
--- a/zaza/openstack/charm_tests/ceilometer_agent/tests.py
+++ b/zaza/openstack/charm_tests/ceilometer_agent/tests.py
@@ -70,7 +70,7 @@ class CeilometerAgentTest(test_utils.OpenStackBaseTest):
         expected_metric_names = self.__get_expected_metric_names(
             current_os_release)
 
-        min_timeout_seconds = 500
+        min_timeout_seconds = 1000
         polling_interval_seconds = (
             openstack_utils.get_application_config_option(
                 self.application_name, 'polling-interval'))


### PR DESCRIPTION
The gate is seeing this failure in the test:

    AssertionError: These metrics should have been published but weren't: disk.root.size, image.size, memory, compute.instance.booting.time, disk.ephemeral.size, image.download, image.serve, vcpus