### PR TITLE
Remove designate-agent for caracal+ testing

### DIFF
--- a/zaza/openstack/charm_tests/designate/tests.py
+++ b/zaza/openstack/charm_tests/designate/tests.py
@@ -44,8 +44,15 @@ class BaseDesignateTest(test_utils.OpenStackBaseTest):
         model_alias = model_alias or ""
         super(BaseDesignateTest, cls).setUpClass(application_name, model_alias)
         os_release = openstack_utils.get_os_release
+        current_release = os_release()
 
-        if os_release() >= os_release('bionic_rocky'):
+        if current_release >= os_release('jammy_caracal'):
+            cls.designate_svcs = [
+                'designate-api', 'designate-central',
+                'designate-mdns', 'designate-worker', 'designate-sink',
+                'designate-producer',
+            ]
+        elif current_release >= os_release('bionic_rocky'):
             cls.designate_svcs = [
                 'designate-agent', 'designate-api', 'designate-central',
                 'designate-mdns', 'designate-worker', 'designate-sink',


### PR DESCRIPTION
The designate-agent service was removed at caracal. This patch removes
the designate-agent from the list of services that designate supports so
that the pause/resume testing works appropriately.
