### PR TITLE
Fixes endpoint discovery for RGW application under test

### DIFF
--- a/zaza/openstack/charm_tests/ceph/tests.py
+++ b/zaza/openstack/charm_tests/ceph/tests.py
@@ -840,13 +840,12 @@ class CephRGWTest(test_utils.BaseCharmTest):
         :param unit_name: Unit name for which RGW endpoint is required.
         :type unit_name: str
         """
-        unit = zaza_model.get_unit_from_name(unit_name)
-        unit_address = zaza_model.get_unit_public_address(
-            unit,
-            self.model_name
-        )
+        # Get address  "public" network binding.
+        unit_address = zaza_model.run_on_unit(
+            unit_name, "network-get public --bind-address"
+        ).get('Stdout', '').strip()
 
-        logging.debug("Unit: {}, Endpoint: {}".format(unit_name, unit_address))
+        logging.info("Unit: {}, Endpoint: {}".format(unit_name, unit_address))
         if unit_address is None:
             return None
         # Evaluate port


### PR DESCRIPTION
Charm-Ceph-RGW configures Apache for Admin/Public bindings. The original test queries the charm for the default public address (i.e. address on the "" binding) to perform object IO (S3) which fails because the endpoint is not correct. For IO test, we need to fetch the address bound to the `PUBLIC` juju space, this PR fetches the same with `network-get` and uses that to perform object IO instead.