### PR TITLE
[main] ObjectRetrierWraps fixes (cherry-pick #1234)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,10 @@ python-novaclient
 python-octaviaclient
 python-swiftclient
 python-watcherclient
-tenacity
+# Due to https://github.com/jd/tenacity/pull/479 the strategy for mocking out tenacity
+# waits/times/etc no longer works.  Pin to 8.4.1 until it is solved.
+# Bug in tenacity tracking issue: https://github.com/jd/tenacity/issues/482
+tenacity<8.4.2
 paramiko
 
 # Documentation requirements

--- a/unit_tests/utilities/test_utilities.py
+++ b/unit_tests/utilities/test_utilities.py
@@ -150,9 +150,7 @@ class TestObjectRetrierWraps(ut_utils.BaseTestCase):
         with self.assertRaises(SomeException):
             wrapped_a.func()
 
-        # there should be two calls; one for the single retry and one for the
-        # failure.
-        self.assertEqual(mock_log.call_count, 6)
+        mock_log.assert_called()
 
     @mock.patch("time.sleep")
     def test_back_off_maximum(self, mock_sleep):

--- a/unit_tests/utilities/test_utilities.py
+++ b/unit_tests/utilities/test_utilities.py
@@ -114,6 +114,28 @@ class TestObjectRetrierWraps(ut_utils.BaseTestCase):
         mock_sleep.assert_not_called()
 
     @mock.patch("time.sleep")
+    def test_object_wrap_multilevel_with_exception(self, mock_sleep):
+
+        class A:
+
+            def func(self):
+                raise SomeException()
+
+        class B:
+
+            def __init__(self):
+                self.a = A()
+
+        b = B()
+        # retry on a specific exception
+        wrapped_b = utilities.ObjectRetrierWraps(
+            b, num_retries=1, retry_exceptions=[SomeException])
+        with self.assertRaises(SomeException):
+            wrapped_b.a.func()
+
+        mock_sleep.assert_called_once_with(5)
+
+    @mock.patch("time.sleep")
     def test_log_called(self, mock_sleep):
 
         class A:
@@ -130,7 +152,7 @@ class TestObjectRetrierWraps(ut_utils.BaseTestCase):
 
         # there should be two calls; one for the single retry and one for the
         # failure.
-        self.assertEqual(mock_log.call_count, 2)
+        self.assertEqual(mock_log.call_count, 6)
 
     @mock.patch("time.sleep")
     def test_back_off_maximum(self, mock_sleep):

--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -99,6 +99,9 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.neutronclient.list_agents.return_value = self.agents
         self.neutronclient.list_bgp_speaker_on_dragent.return_value = \
             self.bgp_speakers
+        self.patch("zaza.openstack.utilities.ObjectRetrierWraps",
+                   name="_object_retrier_wraps",
+                   new=lambda x, *_, **__: x)
 
     def test_create_port(self):
         self.patch_object(openstack_utils, "get_net_uuid")

--- a/zaza/openstack/charm_tests/cinder_backup/tests.py
+++ b/zaza/openstack/charm_tests/cinder_backup/tests.py
@@ -103,7 +103,7 @@ class CinderBackupTest(test_utils.OpenStackBaseTest):
                     self.cinder_client.volumes,
                     cinder_vol.id,
                     wait_iteration_max_time=180,
-                    stop_after_attempt=15,
+                    stop_after_attempt=30,
                     expected_status='available',
                     msg='ceph-backed cinder volume')
 
@@ -125,7 +125,7 @@ class CinderBackupTest(test_utils.OpenStackBaseTest):
                     self.cinder_client.backups,
                     vol_backup.id,
                     wait_iteration_max_time=180,
-                    stop_after_attempt=15,
+                    stop_after_attempt=30,
                     expected_status='available',
                     msg='Backup volume')
 

--- a/zaza/openstack/charm_tests/cinder_backup/tests.py
+++ b/zaza/openstack/charm_tests/cinder_backup/tests.py
@@ -74,7 +74,6 @@ class CinderBackupTest(test_utils.OpenStackBaseTest):
         inspect ceph cinder pool object count as the volume is created
         and deleted.
         """
-        return
         unit_name = zaza.model.get_lead_unit_name('ceph-mon')
         obj_count_samples = []
         pool_size_samples = []

--- a/zaza/openstack/charm_tests/cinder_backup/tests.py
+++ b/zaza/openstack/charm_tests/cinder_backup/tests.py
@@ -22,6 +22,7 @@ import tenacity
 
 import zaza.model
 import zaza.openstack.charm_tests.test_utils as test_utils
+from zaza.openstack.utilities import ObjectRetrierWraps
 import zaza.openstack.utilities.ceph as ceph_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 
@@ -35,8 +36,8 @@ class CinderBackupTest(test_utils.OpenStackBaseTest):
     def setUpClass(cls):
         """Run class setup for running Cinder Backup tests."""
         super(CinderBackupTest, cls).setUpClass()
-        cls.cinder_client = openstack_utils.get_cinder_session_client(
-            cls.keystone_session)
+        cls.cinder_client = ObjectRetrierWraps(
+            openstack_utils.get_cinder_session_client(cls.keystone_session))
 
     @property
     def services(self):

--- a/zaza/openstack/charm_tests/cinder_backup/tests.py
+++ b/zaza/openstack/charm_tests/cinder_backup/tests.py
@@ -22,7 +22,7 @@ import tenacity
 
 import zaza.model
 import zaza.openstack.charm_tests.test_utils as test_utils
-from zaza.openstack.utilities import ObjectRetrierWraps
+from zaza.openstack.utilities import retry_on_connect_failure
 import zaza.openstack.utilities.ceph as ceph_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 
@@ -36,8 +36,9 @@ class CinderBackupTest(test_utils.OpenStackBaseTest):
     def setUpClass(cls):
         """Run class setup for running Cinder Backup tests."""
         super(CinderBackupTest, cls).setUpClass()
-        cls.cinder_client = ObjectRetrierWraps(
-            openstack_utils.get_cinder_session_client(cls.keystone_session))
+        cls.cinder_client = retry_on_connect_failure(
+            openstack_utils.get_cinder_session_client(cls.keystone_session),
+            log=logging.warn)
 
     @property
     def services(self):
@@ -73,6 +74,7 @@ class CinderBackupTest(test_utils.OpenStackBaseTest):
         inspect ceph cinder pool object count as the volume is created
         and deleted.
         """
+        return
         unit_name = zaza.model.get_lead_unit_name('ceph-mon')
         obj_count_samples = []
         pool_size_samples = []

--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -359,7 +359,7 @@ packages:
             self.manila_client.shares,
             share.id,
             wait_iteration_max_time=120,
-            stop_after_attempt=2,
+            stop_after_attempt=10,
             expected_status="available",
             msg="Waiting for a share to become available")
 

--- a/zaza/openstack/utilities/__init__.py
+++ b/zaza/openstack/utilities/__init__.py
@@ -144,7 +144,6 @@ class ObjectRetrierWraps(object):
         wait_so_far = 0
         while True:
             try:
-                log(f"Running {self}({args}, {kwargs})")
                 return obj(*args, **kwargs)
             except Exception as e:
                 # if retry_exceptions is not None, or the type of the exception
@@ -160,16 +159,15 @@ class ObjectRetrierWraps(object):
                     raise
                 retry += 1
                 if retry > num_retries:
-                    log("ObjectRetrierWraps: {}: exceeded number of retries, "
-                        "so erroring out" .format(str(obj)))
+                    log("ObjectRetrierWraps: exceeded number of retries, "
+                        "so erroring out")
                     raise e
-                log("ObjectRetrierWraps: {}: call failed: retrying in {} "
-                    "seconds" .format(str(obj), wait))
+                log("ObjectRetrierWraps: call failed: retrying in {} "
+                    "seconds" .format(wait))
                 time.sleep(wait)
                 wait_so_far += wait
                 if wait_so_far >= total_wait:
                     raise e
-                print('wait: ', wait, '  backoff:', backoff)
                 wait = wait * backoff
                 if wait > max_interval:
                     wait = max_interval


### PR DESCRIPTION
Picked from #1234

- Add ObjectRetrier to CinderaBackupTests
- Add additional debug for ObjectRetrier
- Re-enable test 410 for cinder backups
- Fix ObjectRetrierWraps recursive wrapping
- Double Cinder backup restore time
- Add more retries to allow manila backup restore to complete
- Reduce ObjectRetrierWraps logging noise during normal use
- Modify test code to be less brittle
