### PR TITLE
Added required config option idp_id to Keystone OpenIDC charm

### DIFF
--- a/zaza/openstack/charm_tests/openidc/setup.py
+++ b/zaza/openstack/charm_tests/openidc/setup.py
@@ -141,7 +141,8 @@ def configure_keystone_openidc():
     cfg = {'oidc-client-id': DEFAULT_CLIENT_ID,
            'oidc-client-secret': DEFAULT_CLIENT_SECRET,
            'oidc-provider-metadata-url': url.format(ip=ip,
-                                                    realm=DEFAULT_REALM)}
+                                                    realm=DEFAULT_REALM),
+           'idp_id': IDP}
     zaza.model.set_application_config(APP_NAME, cfg)
     zaza.model.wait_for_agent_status()
     test_config = lifecycle_utils.get_charm_config(fatal=False)


### PR DESCRIPTION
This change makes z-o-t pass in the value of idp_id when configuring the Keystone OpenIDC charm during testing.

(cherry picked from commit 3a6a3f8a632abfaad96d6a48173c3d18baaaeb5d)