### PR TITLE
Fix [magnum].label formatting

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -153,7 +153,7 @@ flavor_id = {{ flavor_ref }}
 dns_nameserver = {{ test_name_server }}
 network_driver = flannel
 {%- if test_registry_prefix %}
-labels = container_infra_prefix:{{ test_registry_prefix }}
+labels = container_infra_prefix={{ test_registry_prefix }}
 insecure_registry = {{ test_registry_prefix }}
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
Fixes the formatting of the labels configuration key, error raised with the current formatting:

    Traceback (most recent call last):
      File "/mnt/git/charmed-openstack-tester/.tox/func-target/lib/python3.8/site-packages/magnum_tempest_plugin/tests/api/base.py", line 39, in setUpClass
    config.Config.setUp()
      File "/mnt/git/charmed-openstack-tester/.tox/func-target/lib/python3.8/site-packages/magnum_tempest_plugin/common/config.py", line 187, in setUp
    cls.set_labels(config)
      File "/mnt/git/charmed-openstack-tester/.tox/func-target/lib/python3.8/site-packages/magnum_tempest_plugin/common/config.py", line 162, in set_labels
    cls.labels = ast.literal_eval(CONF.magnum.labels)
      File "/usr/lib/python3.8/ast.py", line 59, in literal_eval
    node_or_string = parse(node_or_string, mode='eval')
      File "/usr/lib/python3.8/ast.py", line 47, in parse
    return compile(source, filename, mode, flags,
      File "<unknown>", line 1
        container_infra_prefix:10.245.164.190:5000
                              ^
    SyntaxError: invalid syntax