### PR TITLE
Fix formatting in [magnum].labels

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -153,7 +153,7 @@ flavor_id = {{ flavor_ref }}
 dns_nameserver = {{ test_name_server }}
 network_driver = flannel
 {%- if test_registry_prefix %}
-labels = container_infra_prefix={{ test_registry_prefix }}
+labels = {"container_infra_prefix": "{{ test_registry_prefix }}"
 insecure_registry = {{ test_registry_prefix }}
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
magnum-tempest-plugin since commit[0] is using ast.literal_eval() to parse the value set in [magnum].labels, so the formatting needs to be a Python dict.

This is an example of how the string needs to look like to make the parser happy:

```
>>> import ast
>>> ast.literal_eval('{"a": "1:1"}')
{'a': '1:1'}
```

[0] https://opendev.org/openstack/magnum-tempest-plugin/commit/2fe075ae789e06ec58d37dc6f41382e2b64a8343#diff-8e9d4d1beb73d502d61e14564c76d54acf855bf8