### PR TITLE
[yoga] Enable SSL support on manila client

### DIFF
--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -19,10 +19,9 @@
 import logging
 import tenacity
 
-from manilaclient import client as manilaclient
-
 import zaza.model
 import zaza.openstack.configure.guest as guest
+from zaza.openstack.utilities import retry_on_connect_failure
 import zaza.openstack.utilities.generic as generic_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 import zaza.openstack.charm_tests.test_utils as test_utils
@@ -67,8 +66,9 @@ class ManilaTests(test_utils.OpenStackBaseTest):
     def setUpClass(cls):
         """Run class setup for running tests."""
         super(ManilaTests, cls).setUpClass()
-        cls.manila_client = manilaclient.Client(
-            session=cls.keystone_session, client_version='2')
+        cls.manila_client = retry_on_connect_failure(
+            openstack_utils.get_manila_session_client(
+                session=cls.keystone_session))
 
     def test_manila_api(self):
         """Test that the Manila API is working."""
@@ -132,8 +132,8 @@ packages:
         super(ManilaBaseTest, cls).setUpClass()
         cls.nova_client = openstack_utils.get_nova_session_client(
             session=cls.keystone_session)
-        cls.manila_client = manilaclient.Client(
-            session=cls.keystone_session, client_version='2')
+        cls.manila_client = openstack_utils.get_manila_session_client(
+            session=cls.keystone_session)
         cls.share_name = 'test-manila-share'
         cls.share_type_name = 'default_share_type'
         cls.share_protocol = 'nfs'
@@ -221,7 +221,7 @@ packages:
 
         for attempt in tenacity.Retrying(
                 stop=tenacity.stop_after_attempt(5),
-                wait=tenacity.wait_exponential(multiplier=3, min=2, max=10)):
+                wait=tenacity.wait_exponential(multiplier=5, min=2, max=60)):
             with attempt:
                 openstack_utils.ssh_command(
                     vm_name="instance-{}".format(instance_ip),
@@ -233,7 +233,7 @@ packages:
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(5),
-        wait=tenacity.wait_exponential(multiplier=3, min=2, max=10))
+        wait=tenacity.wait_exponential(multiplier=5, min=2, max=60))
     def _write_testing_file_on_instance(self, instance_ip, ssh_user_name,
                                         ssh_private_key):
         """Write a file on a Manila share mounted into a Nova instance.
@@ -260,7 +260,7 @@ packages:
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(5),
-        wait=tenacity.wait_exponential(multiplier=3, min=2, max=10))
+        wait=tenacity.wait_exponential(multiplier=5, min=2, max=60))
     def _clear_testing_file_on_instance(self, instance_ip, ssh_user_name,
                                         ssh_private_key):
         """Clear a file on a Manila share mounted into a Nova instance.
@@ -287,7 +287,7 @@ packages:
 
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(5),
-        wait=tenacity.wait_exponential(multiplier=3, min=2, max=10))
+        wait=tenacity.wait_exponential(multiplier=5, min=2, max=60))
     def _validate_testing_file_from_instance(self, instance_ip, ssh_user_name,
                                              ssh_private_key):
         """Validate a file from the Manila share mounted into a Nova instance.

--- a/zaza/openstack/charm_tests/manila_ganesha/setup.py
+++ b/zaza/openstack/charm_tests/manila_ganesha/setup.py
@@ -20,8 +20,6 @@
 
 import zaza.openstack.utilities.openstack as openstack_utils
 
-from manilaclient import client as manilaclient
-
 
 MANILA_GANESHA_TYPE_NAME = "cephfsnfstype"
 
@@ -34,8 +32,8 @@ def setup_ganesha_share_type(manila_client=None):
     """
     if manila_client is None:
         keystone_session = openstack_utils.get_overcloud_keystone_session()
-        manila_client = manilaclient.Client(
-            session=keystone_session, client_version='2')
+        manila_client = openstack_utils.get_manila_session_client(
+            keystone_session)
 
     manila_client.share_types.create(
         name=MANILA_GANESHA_TYPE_NAME, spec_driver_handles_share_servers=False,

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -452,17 +452,34 @@ def get_aodh_session_client(session):
     return aodh_client.Client(session=session)
 
 
-def get_manila_session_client(session, version='2'):
+def get_manila_session_client(session, version='2', model_name=None):
     """Return Manila client authenticated by keystone session.
 
     :param session: Keystone session object
     :type session: keystoneauth1.session.Session object
     :param version: Manila API version
     :type version: str
+    :param model_name: Optional model name to get the client for.
+    :type model_name: str
     :returns: Authenticated manilaclient
     :rtype: manilaclient.Client
     """
-    return manilaclient.Client(session=session, client_version=version)
+    tls_rid = model.get_relation_id('manila', 'vault',
+                                    model_name=model_name,
+                                    remote_interface_name='certificates')
+    ssl_config = get_application_config_option(
+        'manila',
+        'ssl_cert',
+        model_name=model_name)
+    extra_kwargs = {}
+    if tls_rid or ssl_config:
+        cacert = get_cacert()
+        if cacert:
+            extra_kwargs['cacert'] = cacert
+
+    return manilaclient.Client(session=session,
+                               client_version=version,
+                               **extra_kwargs)
 
 
 def get_keystone_scope(model_name=None):
@@ -2106,6 +2123,7 @@ def get_overcloud_auth(address=None, model_name=None):
     else:
         transport = 'http'
         port = 5000
+    print("transport =", transport, " port=", port)
 
     if not address:
         address = get_keystone_ip(model_name=model_name)
@@ -2145,6 +2163,7 @@ def get_overcloud_auth(address=None, model_name=None):
     if local_ca_cert:
         auth_settings['OS_CACERT'] = local_ca_cert
 
+    print("auth_settings\n", auth_settings)
     return auth_settings
 
 
@@ -2336,6 +2355,8 @@ def _resource_reaches_status(resource, resource_id,
     logging.info("{}: resource {} in {} state, waiting for {}".format(
         msg, resource_id, resource_status, expected_status))
     assert resource_status == expected_status
+    logging.info("{}: resource {} now in {} state".format(
+        msg, resource_id, resource_status))
 
 
 def resource_reaches_status(resource,


### PR DESCRIPTION
The python-manilaclient requires passing the cacert file for TLS
endpoints. This commit enables that on the `get_manila_session_client`
and also, for the manila tests, wraps the client in a retrier that
retries on connection failures (i.e. if the server is not running).

(cherry picked from commit 42afc475cb1507bd1b9619f30380d7efda961a97)
