### PR TITLE
Skip noble image sync for octavia tests

### DIFF
--- a/zaza/openstack/charm_tests/octavia/setup.py
+++ b/zaza/openstack/charm_tests/octavia/setup.py
@@ -35,7 +35,6 @@ def ensure_lts_images():
     glance_setup.add_lts_image(image_name='bionic', release='bionic')
     glance_setup.add_lts_image(image_name='focal', release='focal')
     glance_setup.add_lts_image(image_name='jammy', release='jammy')
-    glance_setup.add_lts_image(image_name='noble', release='noble')
 
 
 def add_amphora_image(image_url=None):


### PR DESCRIPTION
Noble was recently added but is not needed and is tipping glance/ceph storage usage over the limit in release tests.