### PR TITLE
tempest: Deduce min_compute_nodes from Juju model.

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -25,7 +25,7 @@ image_ref = {{ image_id }}
 image_ref_alt = {{ image_alt_id }}
 flavor_ref = {{ flavor_ref }}
 flavor_ref_alt = {{ flavor_ref_alt }}
-min_compute_nodes = 3
+min_compute_nodes = {{ min_compute_nodes }}
 
 # TODO: review this as its release specific
 # min_microversion = 2.2

--- a/zaza/openstack/charm_tests/tempest/utils.py
+++ b/zaza/openstack/charm_tests/tempest/utils.py
@@ -241,6 +241,7 @@ def _add_nova_config(ctxt, keystone_session, missing_fatal=True):
             ctxt['flavor_ref'] = flavor.id
         if flavor.name == TEMPEST_ALT_FLAVOR_NAME:
             ctxt['flavor_ref_alt'] = flavor.id
+    ctxt['min_compute_nodes'] = len(model.get_units('nova-compute'))
 
 
 def _add_neutron_config(ctxt, keystone_session, missing_fatal=True):


### PR DESCRIPTION
At present this value is hard coded, which may cause test failures on deployment with different number of compute nodes.