### PR TITLE
Fallback to 0 minimum compute when no nova-compute units

### DIFF
--- a/zaza/openstack/charm_tests/tempest/utils.py
+++ b/zaza/openstack/charm_tests/tempest/utils.py
@@ -245,7 +245,10 @@ def _add_nova_config(ctxt, keystone_session, missing_fatal=True):
             ctxt['flavor_ref'] = flavor.id
         if flavor.name == TEMPEST_ALT_FLAVOR_NAME:
             ctxt['flavor_ref_alt'] = flavor.id
-    ctxt['min_compute_nodes'] = len(model.get_units('nova-compute'))
+    try:
+        ctxt['min_compute_nodes'] = len(model.get_units('nova-compute'))
+    except KeyError:
+        ctxt['min_compute_nodes'] = 0
 
 
 def _add_neutron_config(ctxt, keystone_session, missing_fatal=True):


### PR DESCRIPTION
Tempests can be used on deployments without nova-compute, testing only control plane APIs. Fallback to a value when no nova-compute units is found.