### PR TITLE
[ussuri] diskimage-retrofit use Focal not Bionic

### DIFF
--- a/zaza/openstack/charm_tests/octavia/diskimage_retrofit/tests.py
+++ b/zaza/openstack/charm_tests/octavia/diskimage_retrofit/tests.py
@@ -55,7 +55,7 @@ class OctaviaDiskimageRetrofitTest(test_utils.OpenStackBaseTest):
         glance = openstack.get_glance_session_client(session)
 
         for image in glance.images.list(filters={'os_distro': 'ubuntu',
-                                                 'os_version': '18.04'}):
+                                                 'os_version': '20.04'}):
             action = zaza.model.run_action(
                 'octavia-diskimage-retrofit/0',
                 'retrofit-image',


### PR DESCRIPTION
If the test uses bionic source image the charm has not be able to determine ubuntu_release which it cant always do. This causes breakage when the image is bionic because it has to apply ussuri uca for retrofit to work.