### PR TITLE
Drop testing on Python 3.6

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -6,12 +6,10 @@ on:
 
 jobs:
   build:
-    # Running on ubuntu-20.04 which has py3.6 support, ubuntu-latest (22.04)
-    # does not (see https://github.com/actions/setup-python/issues/544 ).
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
It was mainly to support test exection from Bionic endpoints which we really don't need any longer.