### PR TITLE
Add tempest target with new RBAC

### DIFF
--- a/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
+++ b/zaza/openstack/charm_tests/tempest/templates/tempest_v3.j2
@@ -47,7 +47,11 @@ auth_version = v3
 admin_role = Admin
 region = RegionOne
 default_domain_id = {{ default_domain_id }}
+{% if admin_domain_scope is defined -%}
+admin_domain_scope = {{ admin_domain_scope }}
+{% else -%}
 admin_domain_scope = true
+{% endif -%}
 disable_ssl_certificate_validation = true
 
 [identity-feature-enabled]
@@ -164,3 +168,10 @@ nameservers = {{ test_name_server }}
 [service-clients]
 # Default is 60s which is not enough for resource constrained environments.
 http_timeout = 120
+
+{% if enforce_scopes is defined and enforce_scopes -%}
+[enforce_scope]
+{% for svc in enforce_scopes -%}
+{{ svc }} = True
+{% endfor -%}
+{% endif -%}

--- a/zaza/openstack/charm_tests/tempest/tests.py
+++ b/zaza/openstack/charm_tests/tempest/tests.py
@@ -156,6 +156,27 @@ class TempestTestWithKeystoneMinimal(TempestTestBase):
         return super().run()
 
 
+class TempestTestWithKeystoneMinimalNewRBAC(TempestTestBase):
+    """Tempest test class to validate an OpenStack setup with Keystone V3.
+
+    Validate the new RBAC model.
+    """
+
+    def run(self):
+        """Run tempest tests as specified in tests/tests.yaml.
+
+        Allow test to run even if some components are missing (like
+        external network setup).
+        See TempestTestBase.run() for the available test options.
+
+        :returns: Status of tempest run
+        :rtype: bool
+        """
+        tempest_utils.render_tempest_config_keystone_v3(minimal=True,
+                                                        new_rbac=True)
+        return super().run()
+
+
 class TempestTestScaleK8SBase(TempestTestBase):
     """Tempest test class to validate an OpenStack setup after scaling."""
 


### PR DESCRIPTION
With Epoxy, new rbacs becomes the default under oslo.policy. Add a new test target TempestTestWithKeystoneMinimalNewRBAC to ensure proper configuration for tempest under new RBAC environments.