### PR TITLE
Pin osc-lib<4.0.0 [xena]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,9 @@ Jinja2>=2.6  # BSD License (3 clause)
 six>=1.9.0
 dnspython>=1.12.0
 psutil>=1.1.1,<2.0.0
+# osc-lib-4.0.0 introduced typing hints making it incompatible with py38.
+# https://github.com/openstack/osc-lib/commit/3d221e5992a74d6bb7d1b725e43015b8c87b9718
+osc-lib<4.0.0; python_version <= '3.8'
 python-openstackclient>=3.14.0
 aodhclient
 gnocchiclient>=7.0.5,<8.0.0

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ install_require = [
     'tenacity',
     'oslo.config<6.12.0',
     'pyparsing<3.0.0',  # pin for aodhclient which is held for py35
+    'osc-lib<4.0.0',  # needed for py38
     'aodhclient<1.4.0',
     'gnocchiclient>=7.0.5,<8.0.0',
     'pika>=1.1.0,<2.0.0',


### PR DESCRIPTION
osc-lib-4.0.0 introduced typing hints making it incompatible with py38.

Ref: https://github.com/openstack/osc-lib/commit/3d221e5992a74d6bb7d1b725e43015b8c87b9718

Resolved Conflicts:
	setup.py

(cherry picked from commit dd72623e0622addc7c46b9c9ae5ae5c8254999c6) (cherry picked from commit ce301ed5676b94a2978fc81d7e6fd6a4beda6d2a)