### PR TITLE
ovn: ovn-central COS Integration tests

### DIFF
--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -128,6 +128,14 @@ class DedicatedChassisCosIntegrationTest(ChassisCosIntegrationTest):
     APPLICATION_NAME = 'ovn-dedicated-chassis'
 
 
+class CentralCosIntegrationTest(BaseCosIntegrationTest):
+    """Variant of COS integration tests for OVN Central."""
+
+    APPLICATION_NAME = 'ovn-central'
+    DASHBOARD = 'Juju: OVN Central (OVSDB)'
+    PROM_QUERY = 'ovn_up'
+
+
 class BaseCharmOperationTest(test_utils.BaseCharmTest):
     """Base OVN Charm operation tests."""
 

--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -866,8 +866,7 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
 
         return sb_status, nb_status
 
-    @staticmethod
-    def _add_unit(number_of_units=1):
+    def _add_unit(self, number_of_units=1):
         """Add specified number of units to ovn-central application.
 
         This function also waits until the application reaches active state.
@@ -877,10 +876,11 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
             count=number_of_units,
             wait_appear=True
         )
-        zaza.model.wait_for_application_states()
+        zaza.model.wait_for_application_states(
+            states=self.test_config.get('target_deploy_status', {}),
+        )
 
-    @staticmethod
-    def _remove_unit(unit_name):
+    def _remove_unit(self, unit_name):
         """Remove specified unit from ovn-central application.
 
         This function also waits until the application reaches active state
@@ -888,7 +888,9 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
         """
         zaza.model.destroy_unit("ovn-central", unit_name)
         zaza.model.block_until_all_units_idle()
-        zaza.model.wait_for_application_states()
+        zaza.model.wait_for_application_states(
+            states=self.test_config.get('target_deploy_status', {}),
+        )
 
     def _assert_servers_cleanly_removed(self, sb_id, nb_id):
         """Assert that specified members were removed from cluster.


### PR DESCRIPTION
This PR contains two commits:
* Fix for OVN downscaling tests that were disregarding `target_deploy_state`
* COS integration tests for `ovn-central` charm