### PR TITLE
ovn: COS integration tests [stable/caracal]

### DIFF
--- a/zaza/openstack/charm_tests/cos/setup.py
+++ b/zaza/openstack/charm_tests/cos/setup.py
@@ -1,0 +1,143 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run configuration phase for cos-agent charm."""
+import logging
+
+from dataclasses import dataclass
+from typing import List
+
+import zaza.charm_lifecycle.utils as lifecycle_utils
+import zaza.controller
+import zaza.model
+
+from juju.client._definitions import ApplicationOfferAdminDetails
+from zaza import sync_wrapper
+
+
+GRAFANA_OFFER_ALIAS = "cos-grafana"
+PROMETHEUS_OFFER_ALIAS = "cos-prometheus"
+
+
+@dataclass
+class CosOffer:
+    """Collection of information about cross-model relation offer.
+
+    :param interface: Interface which at least one endpoint in the offer must
+                      implement.
+    :param role: Role of the interface. Either 'provider' or 'requirer'
+    :param alias: Alias under which is the offer consumed
+    """
+
+    interface: str
+    role: str
+    alias: str
+
+
+COS_OFFERS = [
+    CosOffer("prometheus_remote_write", "provider", PROMETHEUS_OFFER_ALIAS),
+    CosOffer("grafana_dashboard", "requirer", GRAFANA_OFFER_ALIAS),
+]
+
+
+async def async_list_offers(model: str) -> List[ApplicationOfferAdminDetails]:
+    """Return a list of cross-model realtions offered by the model.
+
+    :param model: Name of the model that's searched for the offers
+
+    :returns: List of offers
+    """
+    controller = zaza.controller.Controller()
+    await controller.connect()
+    offer_data = await controller.list_offers(model)
+    await controller.disconnect()
+    return offer_data.get("results", [])
+
+
+async def async_consume_cos_offers(consumer_model_name: str) -> List[CosOffer]:
+    """Consume cross-model relations offers provided by COS model.
+
+    Any offer that contains endpoint with correct interface and a role
+    (defined by COS_OFFERS) will be consumed.
+
+    :param consumer_model_name: Name of the model that should consume offers
+
+    :returns: List of CosOffer that were consumed
+    """
+    consumed_offers = []
+    consumer = await zaza.model.get_model(consumer_model_name)
+
+    for model_name in await zaza.controller.async_list_models():
+        for offer in await async_list_offers(model_name):
+            for endpoint in offer.endpoints:
+                for cos_ep in COS_OFFERS:
+                    if (
+                        endpoint.interface == cos_ep.interface and
+                        endpoint.role == cos_ep.role
+                    ):
+                        logging.info(
+                            f"Consuming offer: {offer.offer_url}"
+                            f" under alias {cos_ep.alias}"
+                        )
+                        await consumer.consume(offer.offer_url, cos_ep.alias)
+                        consumed_offers.append(cos_ep)
+
+    return consumed_offers
+
+
+consume_cos_offers = sync_wrapper(async_consume_cos_offers)
+
+
+async def async_relate_grafana_agent(
+    model_name: str, cos_offers: List[CosOffer]
+) -> None:
+    """Relate application grafana-agent to the offered COS applications.
+
+    :param model_name: Name of the model in which grafana-agent resides.
+    :param cos_offers: List of cross-model relation offers to which
+                       grafana-agent should be related.
+
+    :returns: None
+    """
+    model = await zaza.model.get_model(model_name)
+    for cos_ep in cos_offers:
+        logging.info(f"Relating grafana-agent to offer {cos_ep.alias}")
+        await model.integrate("grafana-agent", cos_ep.alias)
+
+
+relate_grafana_agent = sync_wrapper(async_relate_grafana_agent)
+
+
+def try_relate_to_cos():
+    """Attempt to relate grafana-agent with COS applications."""
+    logging.info(
+        "Attempting to relate grafana-agent to COS via cross-model relations"
+    )
+    model = zaza.model.get_juju_model()
+    cos_offers = consume_cos_offers(model)
+    if cos_offers:
+        relate_grafana_agent(model, cos_offers)
+        zaza.model.wait_for_agent_status()
+        test_config = lifecycle_utils.get_charm_config(fatal=False)
+        test_config['target_deploy_status']['grafana-agent'][
+            'workload-status'
+        ] = 'active'
+        zaza.model.wait_for_application_states(
+            states=test_config.get("target_deploy_status", {}), timeout=7200
+        )
+    else:
+        logging.warn(
+            "No COS cross-model relation offers found. grafana-agent"
+            " will remain blocked"
+        )

--- a/zaza/openstack/charm_tests/neutron/setup.py
+++ b/zaza/openstack/charm_tests/neutron/setup.py
@@ -66,6 +66,7 @@ DEFAULT_UNDERCLOUD_NETWORK_CONFIG = {
     "external_dns": "10.5.0.2",
     "external_net_cidr": "10.5.0.0/16",
     "default_gateway": "10.5.0.1",
+    "lxd_network_name": "second",
 }
 
 # For Neutron Dynamic Tests it is useful to avoid relying on the directly
@@ -115,6 +116,12 @@ def undercloud_and_charm_setup(limit_gws=None):
         #
         # Perform charm based OVS configuration
         openstack_utils.configure_charmed_openstack_on_maas(
+            network_config, limit_gws=limit_gws)
+    elif provider_type == "lxd" or provider_type is None:
+        # NOTE(fnordahl): When juju is bootstrapped towards the special
+        # `localhost` LXD cloud, get_provider_type() has no `clouds.yaml` to
+        # inspect and returns None.
+        openstack_utils.configure_charmed_openstack_on_lxd(
             network_config, limit_gws=limit_gws)
     else:
         logging.warning('Unknown Juju provider type, "{}", will not perform'

--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -128,6 +128,14 @@ class DedicatedChassisCosIntegrationTest(ChassisCosIntegrationTest):
     APPLICATION_NAME = 'ovn-dedicated-chassis'
 
 
+class CentralCosIntegrationTest(BaseCosIntegrationTest):
+    """Variant of COS integration tests for OVN Central."""
+
+    APPLICATION_NAME = 'ovn-central'
+    DASHBOARD = 'Juju: OVN Central (OVSDB)'
+    PROM_QUERY = 'ovn_up'
+
+
 class BaseCharmOperationTest(test_utils.BaseCharmTest):
     """Base OVN Charm operation tests."""
 

--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -133,7 +133,9 @@ class CentralCosIntegrationTest(BaseCosIntegrationTest):
 
     APPLICATION_NAME = 'ovn-central'
     DASHBOARD = 'Juju: OVN Central (OVSDB)'
-    PROM_QUERY = 'ovn_up'
+    # make sure to test metric that requires successful connection
+    # of the exporter to the OVN sockets
+    PROM_QUERY = 'ovn_coverage_total'
 
 
 class BaseCharmOperationTest(test_utils.BaseCharmTest):

--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -486,8 +486,14 @@ class DPDKTest(test_utils.BaseCharmTest):
         logging.info('Post-flight check')
         self._dpdk_pre_post_flight_check()
 
-        self.disable_hugepages_vfio_on_hvs_in_vms()
-        self._ovs_br_ex_port_is_system_interface()
+        # Note(mkalcok): There's currently a bug in Juju that prevents
+        # rebooting machine 2nd time after adding second NIC
+        # (https://github.com/juju/juju/issues/19463). To unblock CI,
+        # we temorarily skip steps to disable hugepages, because they include
+        # reboot.
+        #
+        # self.disable_hugepages_vfio_on_hvs_in_vms()
+        # self._ovs_br_ex_port_is_system_interface()
 
 
 class OVSOVNMigrationTest(test_utils.BaseCharmTest):

--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -860,8 +860,7 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
 
         return sb_status, nb_status
 
-    @staticmethod
-    def _add_unit(number_of_units=1):
+    def _add_unit(self, number_of_units=1):
         """Add specified number of units to ovn-central application.
 
         This function also waits until the application reaches active state.
@@ -871,10 +870,11 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
             count=number_of_units,
             wait_appear=True
         )
-        zaza.model.wait_for_application_states()
+        zaza.model.wait_for_application_states(
+            states=self.test_config.get('target_deploy_status', {}),
+        )
 
-    @staticmethod
-    def _remove_unit(unit_name):
+    def _remove_unit(self, unit_name):
         """Remove specified unit from ovn-central application.
 
         This function also waits until the application reaches active state
@@ -882,7 +882,9 @@ class OVNCentralDownscaleTests(test_utils.BaseCharmTest):
         """
         zaza.model.destroy_unit("ovn-central", unit_name)
         zaza.model.block_until_all_units_idle()
-        zaza.model.wait_for_application_states()
+        zaza.model.wait_for_application_states(
+            states=self.test_config.get('target_deploy_status', {}),
+        )
 
     def _assert_servers_cleanly_removed(self, sb_id, nb_id):
         """Assert that specified members were removed from cluster.

--- a/zaza/openstack/charm_tests/test_utils.py
+++ b/zaza/openstack/charm_tests/test_utils.py
@@ -757,8 +757,9 @@ class BaseCharmTest(unittest.TestCase):
                              ' recover. Possible cause:'
                              ' https://bugs.launchpad.net/juju/+bug/2077936')
                 zaza.model.resolve_units()
-                zaza.utilities.machine_os.enable_vfio_unsafe_noiommu_mode(
-                    unit, model_name=self.model_name)
+                model.wait_for_application_states(
+                    model_name=self.model_name,
+                    states=self.test_config.get('target_deploy_status', {}))
 
     def disable_hugepages_vfio_on_hvs_in_vms(self):
         """Disable hugepages and unsafe VFIO NOIOMMU on virtual hypervisors."""

--- a/zaza/openstack/utilities/generic.py
+++ b/zaza/openstack/utilities/generic.py
@@ -190,6 +190,7 @@ def get_undercloud_env_vars():
     _vars['external_dns'] = os.environ.get('TEST_NAME_SERVER')
     _vars['default_gateway'] = os.environ.get('TEST_GATEWAY')
     _vars['external_net_cidr'] = os.environ.get('TEST_CIDR_EXT')
+    _vars['lxd_network_name'] = os.environ.get('TEST_LXD_NETWORK_NAME')
 
     # Take FIP_RANGE and create start and end floating ips
     _fip_range = os.environ.get('TEST_FIP_RANGE')
@@ -205,7 +206,8 @@ def get_undercloud_env_vars():
              'start_floating_ip',
              'end_floating_ip',
              'external_dns',
-             'external_net_cidr']
+             'external_net_cidr',
+             'lxd_network_name']
     for _key in _keys:
         _val = os.environ.get(_key)
         if _val:

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -25,6 +25,7 @@ import itertools
 import json
 import juju_wait
 import logging
+import netaddr
 import os
 import paramiko
 import pathlib
@@ -1175,6 +1176,70 @@ def configure_charmed_openstack_on_maas(network_config, limit_gws=None):
                      .format(mim.machine_id, mim.ifname, mim.mac))
         machines.add(mim.machine_id)
         macs.append(mim.mac)
+
+    if macs:
+        configure_networking_charms(
+            networking_data, macs, use_juju_wait=False)
+
+
+def lxd_maybe_add_nic(instance, ifname, network):
+    """Add NIC to instance.
+
+    :param instance: Name of instance.
+    :type instance: str
+    :param ifname: Name of interface inside instance, note that name is only
+                   preserved in containers, interfaces in virtual machines are
+                   subject to udev rules inside the instance.
+    :type: ifname: str
+    :param network: Name of network.
+    :type network: str
+    """
+    try:
+        subprocess.check_call([
+            "lxc", "config", "device", "add", instance,
+            ifname, "nic", "name={}".format(ifname),
+            "network={}".format(network)])
+    except subprocess.CalledProcessError:
+        logging.info("Unable to add device {} to {}, already added?"
+                     .format(ifname, instance))
+
+
+def lxd_get_nic_hwaddr(instance, device_name):
+    """Add NIC to instance.
+
+    :param instance: Name of instance.
+    :type instance: str
+    :param device_name: Name of device config.
+    :type device_name: str
+    :rtype: netaddr.EUI
+    :raises: netaddr.core.AddrFormatError in the event nic does not exist.
+    """
+    # lxc config get succeeds even for non-existing keys.
+    output = subprocess.check_output([
+        "lxc", "config", "get", instance,
+        "volatile.{}.hwaddr".format(device_name)],
+        universal_newlines=True)
+
+    mac = netaddr.EUI(output)
+    mac.dialect = netaddr.mac_unix_expanded
+    return mac
+
+
+def configure_charmed_openstack_on_lxd(network_config, limit_gws=None):
+    """Configure networking charms for charm-based OVS config on LXD provider.
+
+    :param network_config: Network configuration as provided in environment.
+    :type network_config: Dict[str]
+    :param limit_gws: Limit the number of gateways that get a port attached
+    :type limit_gws: Optional[int]
+    """
+    networking_data = get_charm_networking_data(limit_gws=limit_gws)
+    ifname = "eth1"
+    macs = []
+    for instance in networking_data.unit_machine_ids:
+        lxd_maybe_add_nic(instance, ifname,
+                          network_config.get("lxd_network_name"))
+        macs.append(str(lxd_get_nic_hwaddr(instance, ifname)))
 
     if macs:
         configure_networking_charms(


### PR DESCRIPTION
This PR is mostly backport that introduces OVN COS integration tests to caracal branch. It includes:
* #1277 
* #1309 
* #1311 
* #1323
* #1325 
* #1326 
* f4f9854631a74e6897222f87f023812a01c76f68

I'm putting this PR into draft state while we verify that OVN charms 24.03 are passing with it.