### PR TITLE
ovn: Change metric that verifies OVN exporter

### DIFF
--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -133,7 +133,9 @@ class CentralCosIntegrationTest(BaseCosIntegrationTest):
 
     APPLICATION_NAME = 'ovn-central'
     DASHBOARD = 'Juju: OVN Central (OVSDB)'
-    PROM_QUERY = 'ovn_up'
+    # make sure to test metric that requires successful connection
+    # of the exporter to the OVN sockets
+    PROM_QUERY = 'ovn_coverage_total'
 
 
 class BaseCharmOperationTest(test_utils.BaseCharmTest):


### PR DESCRIPTION
It is possible for OVN exporter to run even if it
can't connect to OVN sockets. In that case it will report only reduced number of metrics. We need to
use metric that confirms that the exporter is successfully connected to the OVN.