### PR TITLE
ovn: Make "Prometheus" and "HW Offload" tests skippable.

### DIFF
--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -15,6 +15,7 @@
 """Encapsulate OVN testing."""
 
 import logging
+import os
 import unittest
 
 import juju
@@ -229,6 +230,10 @@ class BaseCharmOperationTest(test_utils.BaseCharmTest):
 
     def test_prometheus_exporter_reachable(self):
         """Ensure that the OVS/OVN exporter responds to requests."""
+        if os.environ.get('TEST_SKIP_PROMETHEUS') is not None:
+            self.skipTest('Prometheus testing skipped becuase '
+                          'TEST_SKIP_PROMETHEUS env is set.')
+
         for unit in zaza.model.get_units(self.application_name):
             ip = zaza.model.get_unit_public_address(unit)
             response = requests.get(

--- a/zaza/openstack/charm_tests/ovn/tests.py
+++ b/zaza/openstack/charm_tests/ovn/tests.py
@@ -362,6 +362,10 @@ class ChassisCharmOperationTest(BaseCharmOperationTest):
 
     def test_enable_hardware_offload(self):
         """Confirm that chassis can configure OVS hardware offload."""
+        if os.environ.get('TEST_SKIP_HW_OFFLOAD') is not None:
+            self.skipTest('Hardware Offload testing skipped becuase '
+                          'TEST_SKIP_HW_OFFLOAD env is set.')
+
         with self.config_change(
                 {'enable-hardware-offload': 'false'},
                 {'enable-hardware-offload': 'true'}):


### PR DESCRIPTION
In order to use GH runners for functional tests of OVN chassis charms, we need the support for LXD VMs in Juju. This feature is supported since 3.1, but unfortunately, `zaza` and `zaza-openstack-tests` in `stable/yoga` branch don't support Juju3.
A solution for `22.03` releases of `ovn-chassis` and `ovn-dedicated-chassis`, which until now used zaza `stable/yoga`, is to upgrade zaza to `stable/caracal`. This works fine in general and brings us a lot of fixes that were already backported to this branch, but we need to make couple tests optional, because the functionality is not present in `22.03` version of charms. Optional tests are controlled via environment variables.

* Exporting `TEST_SKIP_PROMETHEUS` skips test for reachability of prometheus exporter
* Exporting `TEST_SKIP_HW_OFFLOAD` skips test for "Hardware offload"