### PR TITLE
Pin setuptools<82 in constraints and requirements

### DIFF
--- a/constraints/constraints-2024.1.txt
+++ b/constraints/constraints-2024.1.txt
@@ -11,3 +11,7 @@ juju>=2.9.0,<3.0.0
 # netaddr>=1.0.0 has incompatible changes, see
 # https://netaddr.readthedocs.io/en/latest/changes.html#release-1-0-0
 netaddr<1.0.0
+
+# setuptools>=82 removes deprecated pkg_resources.declare_namespace(),
+# breaking several OpenStack client libraries.
+setuptools<82

--- a/constraints/constraints-master.txt
+++ b/constraints/constraints-master.txt
@@ -7,3 +7,7 @@
 # * zaza-openstack-tests
 #
 juju>=3.1.0,<3.2.0
+
+# setuptools>=82 removes deprecated pkg_resources.declare_namespace(),
+# breaking several OpenStack client libraries.
+setuptools<82

--- a/constraints/constraints-noble.txt
+++ b/constraints/constraints-noble.txt
@@ -7,3 +7,7 @@
 # * zaza-openstack-tests
 #
 juju>=3.5.0,<3.6.0
+
+# setuptools>=82 removes deprecated pkg_resources.declare_namespace(),
+# breaking several OpenStack client libraries.
+setuptools<82

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,7 @@ git+https://github.com/openstack-charmers/zaza#egg=zaza
 # * https://github.com/openstack-charmers/zaza/issues/421
 # * https://mail.python.org/pipermail/cryptography-dev/2021-January/001003.html
 cryptography<3.4
+
+# setuptools>=82 removes pkg_resources.declare_namespace() which is still
+# used by several OpenStack client libraries (keystoneclient, etc).
+setuptools<82


### PR DESCRIPTION
setuptools>=82 removes the deprecated pkg_resources.declare_namespace() which breaks several OpenStack client libraries that still rely on it.

Refs https://github.com/openstack-charmers/zaza-openstack-tests/issues/1339