### PR TITLE
constraints: Constrain setuptools.

### DIFF
--- a/constraints/constraints-master.txt
+++ b/constraints/constraints-master.txt
@@ -7,3 +7,7 @@
 # * zaza-openstack-tests
 #
 juju>=3.1.0,<3.2.0
+
+# There are multiple direct dependencies pulled in from `setup.py` that do not
+# work with a setuptools that does not offer `pkg_resources`.
+setuptools<82

--- a/constraints/constraints-noble.txt
+++ b/constraints/constraints-noble.txt
@@ -7,3 +7,7 @@
 # * zaza-openstack-tests
 #
 juju>=3.5.0,<3.6.0
+
+# There are multiple direct dependencies pulled in from `setup.py` that do not
+# work with a setuptools that does not offer `pkg_resources`.
+setuptools<82


### PR DESCRIPTION
There are multiple direct dependencies pulled in from `setup.py` that do not work with a setuptools that does not offer `pkg_resources`.