### PR TITLE
Add barbican policyd tests

### DIFF
--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -40,6 +40,7 @@ import unittest
 import zipfile
 
 from octaviaclient.api.v2 import octavia as octaviaclient
+import barbicanclient.exceptions
 import cinderclient.exceptions
 import heatclient.exc
 import glanceclient.common.exceptions
@@ -713,5 +714,35 @@ class OctaviaTests(BasePolicydSpecialization):
             octavia_client.provider_list()
             self.run_resource_cleanup = True
         except (octaviaclient.OctaviaClientException,
+                keystoneauth1.exceptions.http.Forbidden):
+            raise PolicydOperationFailedException()
+
+
+class BarbicanTests(BasePolicydSpecialization):
+    """Test the policyd override using the barbican client."""
+
+    _rule = {'rule.yaml': "{'secrets:get': '!'}"}
+
+    @classmethod
+    def setUpClass(cls, application_name=None):
+        """Run class setup for running BarbicanTests charm operation tests."""
+        super(BarbicanTests, cls).setUpClass(application_name="barbican")
+        cls.application_name = "barbican"
+
+    def get_client_and_attempt_operation(self, ip):
+        """Attempt to list secrets as a policyd override.
+
+        This operation should pass normally, and fail when
+        the rule has been overriden (see the `rule` class variable).
+
+        :param ip: the IP address to get the session against.
+        :type ip: str
+        :raises: PolicydOperationFailedException if operation fails.
+        """
+        barbican = openstack_utils.get_barbican_session_client(
+            self.get_keystone_session_admin_user(ip))
+        try:
+            barbican.secrets.list()
+        except (barbicanclient.exceptions.HTTPClientError,
                 keystoneauth1.exceptions.http.Forbidden):
             raise PolicydOperationFailedException()

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -51,6 +51,7 @@ from .os_versions import (
 from openstack import connection
 
 from aodhclient.v2 import client as aodh_client
+from barbicanclient import client as barbicanclient
 from cinderclient import client as cinderclient
 from heatclient import client as heatclient
 from magnumclient import client as magnumclient
@@ -442,6 +443,17 @@ def get_octavia_session_client(session, service_type='load-balancer',
     return octaviaclient.OctaviaAPI(session=session,
                                     service_type=service_type,
                                     endpoint=endpoint.url)
+
+
+def get_barbican_session_client(session):
+    """Return barbicanclient authenticated by keystone session.
+
+    :param session: Keystone session object
+    :type session: keystoneauth1.session.Session object
+    :returns: Authenticated barbicanclient
+    :rtype: barbicanclient.client.Client object
+    """
+    return barbicanclient.Client(session=session)
 
 
 def get_heat_session_client(session, version=1):


### PR DESCRIPTION
Add `BarbicanTests` to policyd tests, using the `secrets:get` rule to verify policy overrides work with the Barbican charm.

(cherry picked from commit dc1780da28fd8fd1a39c0283cdbb5c7c9405ea56)
(cherry picked from commit e585c60cdbbe9a4237c81da9f36f41361b7316f5)