### PR TITLE
Fix barbican policyd tests

### DIFF
--- a/zaza/openstack/charm_tests/policyd/tests.py
+++ b/zaza/openstack/charm_tests/policyd/tests.py
@@ -40,8 +40,7 @@ import unittest
 import zipfile
 
 from octaviaclient.api.v2 import octavia as octaviaclient
-import barbicanclient.client as barbican_client
-import barbicanclient.exceptions as barbican_exceptions
+import barbicanclient.exceptions
 import cinderclient.exceptions
 import heatclient.exc
 import glanceclient.common.exceptions
@@ -740,15 +739,10 @@ class BarbicanTests(BasePolicydSpecialization):
         :type ip: str
         :raises: PolicydOperationFailedException if operation fails.
         """
-        keystone_session = self.get_keystone_session_admin_user(ip)
-        keystone_client = openstack_utils.get_keystone_session_client(
-            keystone_session)
-        barbican_endpoint = keystone_client.service_catalog.url_for(
-            service_type='key-manager', interface='publicURL')
-        barbican = barbican_client.Client(
-            session=keystone_session, endpoint=barbican_endpoint)
+        barbican = openstack_utils.get_barbican_session_client(
+            self.get_keystone_session_admin_user(ip))
         try:
             barbican.secrets.list()
-        except (barbican_exceptions.HTTPClientError,
+        except (barbicanclient.exceptions.HTTPClientError,
                 keystoneauth1.exceptions.http.Forbidden):
             raise PolicydOperationFailedException()

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -53,6 +53,7 @@ from .os_versions import (
 from openstack import connection
 
 from aodhclient.v2 import client as aodh_client
+from barbicanclient import client as barbicanclient
 from cinderclient import client as cinderclient
 from heatclient import client as heatclient
 from magnumclient import client as magnumclient
@@ -448,6 +449,17 @@ def get_octavia_session_client(session, service_type='load-balancer',
     return octaviaclient.OctaviaAPI(session=session,
                                     service_type=service_type,
                                     endpoint=endpoint.url)
+
+
+def get_barbican_session_client(session):
+    """Return barbicanclient authenticated by keystone session.
+
+    :param session: Keystone session object
+    :type session: keystoneauth1.session.Session object
+    :returns: Authenticated barbicanclient
+    :rtype: barbicanclient.client.Client object
+    """
+    return barbicanclient.Client(session=session)
 
 
 def get_heat_session_client(session, version=1):


### PR DESCRIPTION
The `BarbicanTests.get_client_and_attempt_operation()` method was manually resolving the barbican endpoint via `keystone_client.service_catalog.url_for()`,  which fails because session-based keystone clients don't populate service_catalog.

- Add `get_barbican_session_client()` to `zaza.openstack.utilities.openstack`, following the same pattern as `get_heat_session_client()` and other service clients
- Update `BarbicanTests` to use `openstack_utils.get_barbican_session_client()`, which lets the barbican client resolve the endpoint from the session automatically