### PR TITLE
[bobcat] Launch vms with http proxy

### DIFF
--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -28,6 +28,7 @@ import zaza.model
 import zaza.openstack.charm_tests.tempest.tests as tempest_tests
 import zaza.openstack.charm_tests.test_utils as test_utils
 import zaza.openstack.utilities.openstack as openstack_utils
+from zaza.openstack.configure.guest import get_default_userdata
 
 from zaza.openstack.utilities import generic as generic_utils
 from zaza.openstack.utilities import ObjectRetrierWraps
@@ -461,7 +462,7 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         return subprocess.check_output(
             ['wget', '-O', '-',
              'http://{}/'.format(ip)],
-            universal_newlines=True)
+            universal_newlines=True, env={'no_proxy': ip})
 
     def create_loadbalancer(self, ensure_volume_backed=False):
         """Create load balancer."""
@@ -481,7 +482,7 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         # Then we request two Ubuntu instances with the Apache web server
         # installed
         instance_1, instance_2 = self.launch_guests(
-            userdata='#cloud-config\npackages:\n - apache2\n')
+            userdata=get_default_userdata() + 'packages:\n - apache2\n')
 
         # Get IP of the prepared payload instances
         payload_ips = []

--- a/zaza/openstack/configure/guest.py
+++ b/zaza/openstack/configure/guest.py
@@ -23,6 +23,7 @@ import time
 import zaza.openstack.utilities.openstack as openstack_utils
 import zaza.openstack.charm_tests.nova.utils as nova_utils
 import zaza.openstack.utilities.exceptions as openstack_exceptions
+import zaza.utilities.deployment_env as deployment_env
 
 from tenacity import (
     RetryError,
@@ -30,6 +31,22 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
+
+
+DEFAULT_USER_DATA = """#cloud-config
+apt:
+  http_proxy: {http_proxy}
+
+write_files:
+  - path: /etc/environment
+    content: |
+      http_proxy={http_proxy}
+      https_proxy={https_proxy}
+      no_proxy={no_proxy}
+    append: true
+
+"""
+
 
 boot_tests = {
     'cirros': {
@@ -89,6 +106,20 @@ def launch_instance_retryer(instance_key, **kwargs):
         **kwargs
     )
     return instance
+
+
+def get_default_userdata():
+    """
+    Get default guest vm userdata.
+
+    If http proxy settings are available create a userdata file to enable them
+    inside launched guest vms.
+    """
+    deploy_env = deployment_env.get_deployment_context()
+    return DEFAULT_USER_DATA.format(
+        http_proxy=deploy_env.get('TEST_HTTP_PROXY'),
+        https_proxy=deploy_env.get('TEST_HTTP_PROXY'),
+        no_proxy=deploy_env.get('TEST_NO_PROXY'))
 
 
 def launch_instance(instance_key, use_boot_volume=False, vm_name=None,
@@ -188,7 +219,7 @@ def launch_instance(instance_key, use_boot_volume=False, vm_name=None,
         key_name=nova_utils.KEYPAIR_NAME,
         meta=meta,
         nics=nics,
-        userdata=userdata,
+        userdata=userdata or get_default_userdata(),
         host=host,
     )
 


### PR DESCRIPTION
If an http proxy is available we need to set it in launched vms to allow them to access external sites.

Also use no_proxy for test fip when accessing vm in octavia test.

(cherry picked from commit 3e30ece2c6d85997fc6fb9ad50f2cb9ad20006c1)