### PR TITLE
Retry pacemaker remote

### DIFF
--- a/zaza/openstack/charm_tests/pacemaker_remote/tests.py
+++ b/zaza/openstack/charm_tests/pacemaker_remote/tests.py
@@ -18,6 +18,7 @@
 
 import unittest
 
+import tenacity
 import zaza.model
 import zaza.openstack.configure.hacluster
 import zaza.openstack.utilities.generic as generic_utils
@@ -28,11 +29,30 @@ class PacemakerRemoteTest(unittest.TestCase):
 
     def test_check_nodes_online(self):
         """Test that all nodes are online."""
+        for attempt in tenacity.Retrying(
+            reraise=True,
+            stop=tenacity.stop_after_attempt(5),
+            wait=tenacity.wait_fixed(5),
+        ):
+            with attempt:
+                zaza.openstack.configure.hacluster.check_all_nodes_online(
+                    'api'
+                )
         units = zaza.model.get_units('pacemaker-remote')
         last_unit = units[-1]
-        node_name = generic_utils.get_unit_hostnames(units)[last_unit.entity_id]
+        node_names = generic_utils.get_unit_hostnames(units)
+        node_name = node_names[last_unit.entity_id]
         zaza.openstack.configure.hacluster.remove_node(
             'api',
             node_name)
-        self.assertTrue(
-            zaza.openstack.configure.hacluster.check_all_nodes_online('api'))
+        for attempt in tenacity.Retrying(
+            reraise=True,
+            stop=tenacity.stop_after_attempt(5),
+            wait=tenacity.wait_fixed(5),
+        ):
+            with attempt:
+                self.assertTrue(
+                    zaza.openstack.configure.hacluster.check_all_nodes_online(
+                        'api'
+                    )
+                )

--- a/zaza/openstack/charm_tests/pacemaker_remote/tests.py
+++ b/zaza/openstack/charm_tests/pacemaker_remote/tests.py
@@ -18,7 +18,9 @@
 
 import unittest
 
+import zaza.model
 import zaza.openstack.configure.hacluster
+import zaza.openstack.utilities.generic as generic_utils
 
 
 class PacemakerRemoteTest(unittest.TestCase):
@@ -26,8 +28,11 @@ class PacemakerRemoteTest(unittest.TestCase):
 
     def test_check_nodes_online(self):
         """Test that all nodes are online."""
+        units = zaza.model.get_units('pacemaker-remote')
+        last_unit = units[-1]
+        node_name = generic_utils.get_unit_hostnames(units)[last_unit.entity_id]
         zaza.openstack.configure.hacluster.remove_node(
             'api',
-            'node1')
+            node_name)
         self.assertTrue(
             zaza.openstack.configure.hacluster.check_all_nodes_online('api'))


### PR DESCRIPTION
Make the test for pacemake-remote more robust by using tenacity to retry and cover for race conditions while pacemaker settles, and drop hardcoded node name in favor of picking a node from the available units.