### PR TITLE
Use https proxy for redirected image downloads

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -327,7 +327,8 @@ class TestOpenStackUtils(ut_utils.BaseTestCase):
         self.ProxyHandler.return_value = ProxyHandler_mock
         openstack_utils.get_urllib_opener()
         self.build_opener.assert_called_once_with(ProxyHandler_mock)
-        self.ProxyHandler.assert_called_once_with({'http': 'http://squidy'})
+        self.ProxyHandler.assert_called_once_with(
+            {'http': 'http://squidy', 'https': 'http://squidy'})
 
     def test_get_images_by_name(self):
         image_mock1 = mock.MagicMock()

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -2430,15 +2430,27 @@ def get_urllib_opener():
     via TEST_HTTP_PROXY rather than http_proxy so a ProxyHandler is needed
     explicitly stating the proxies.
 
+    Both http and https proxies are configured: some image downloads are
+    served over http but redirect to https (cirros now redirects to
+    github.com), so an http-only proxy would let the https request bypass
+    the proxy and fail where external access is proxy-only.
+
     :returns: An opener which opens URLs via BaseHandlers chained together
     :rtype: urllib.request.OpenerDirector
     """
     deploy_env = deployment_env.get_deployment_context()
     http_proxy = deploy_env.get('TEST_HTTP_PROXY')
-    logging.debug('TEST_HTTP_PROXY: {}'.format(http_proxy))
+    https_proxy = deploy_env.get('TEST_HTTPS_PROXY') or http_proxy
+    logging.debug('TEST_HTTP_PROXY: {} TEST_HTTPS_PROXY: {}'.format(
+        http_proxy, https_proxy))
 
+    proxies = {}
     if http_proxy:
-        handler = urllib.request.ProxyHandler({'http': http_proxy})
+        proxies['http'] = http_proxy
+    if https_proxy:
+        proxies['https'] = https_proxy
+    if proxies:
+        handler = urllib.request.ProxyHandler(proxies)
     else:
         handler = urllib.request.HTTPHandler()
     return urllib.request.build_opener(handler)


### PR DESCRIPTION
get_urllib_opener only set an http proxy from TEST_HTTP_PROXY.
Image downloads start on 
http://download.cirros-cloud.net/0.6.3/cirros-0.6.3-x86_64-disk.img but the server now redirects to https://github.com/cirros-dev/cirros/releases/download/0.6.3/cirros-0.6.3-x86_64-disk.img
, and with an http-only ProxyHandler the https request bypasses the proxy and connects directly.
Where external access is only reachable through a proxy this times out.

Also set an https proxy from TEST_HTTPS_PROXY (falling back to TEST_HTTP_PROXY) so the redirected https request goes through the proxy.

Tested in PS7 bastion

```
#!/bin/bash -eu

for ps in http_proxy https_proxy no_proxy; do
    export TEST_${ps^^}=${!ps:-""}
done

py=.tox/func-target/bin/python
[[ -x $py ]] || py=src/.tox/func-target/bin/python

# 1) as-is: zaza's real get_urllib_opener (http proxy only)
"$py" - << 'PY'
import os, socket, tempfile
socket.setdefaulttimeout(30)
from zaza.openstack.utilities.openstack import find_cirros_image, download_image
url = find_cirros_image('x86_64')
print("TEST_HTTP_PROXY =", os.environ.get('TEST_HTTP_PROXY'))
print("url =", url)
dest = tempfile.mktemp(suffix='-cirros.img')
try:
    download_image(url, dest); print("[http-only] OK", os.path.getsize(dest)); os.remove(dest)
except Exception as e:
    print("[http-only] FAIL", type(e).__name__, e)
PY

# 2) with the +https fix: patch get_urllib_opener to also proxy https
"$py" - << 'PY'
import os, socket, tempfile, urllib.request
socket.setdefaulttimeout(30)
import zaza.openstack.utilities.openstack as zo
from zaza.utilities import deployment_env

def opener_with_https():
    de = deployment_env.get_deployment_context()
    hp = de.get('TEST_HTTP_PROXY')
    sp = de.get('TEST_HTTPS_PROXY') or hp
    proxies = {}
    if hp:
        proxies['http'] = hp
    if sp:
        proxies['https'] = sp
    h = urllib.request.ProxyHandler(proxies) if proxies else urllib.request.HTTPHandler()
    return urllib.request.build_opener(h)
zo.get_urllib_opener = opener_with_https

url = zo.find_cirros_image('x86_64')
dest = tempfile.mktemp(suffix='-cirros.img')
try:
    zo.download_image(url, dest); print("[+https]    OK", os.path.getsize(dest)); os.remove(dest)
except Exception as e:
    print("[+https]    FAIL", type(e).__name__, e)
PY
```