### PR TITLE
[stable/yoga] Fix designate-bind ServiceIPs test wait states

### DIFF
--- a/zaza/openstack/charm_tests/designate_bind/tests.py
+++ b/zaza/openstack/charm_tests/designate_bind/tests.py
@@ -16,6 +16,13 @@
 import logging
 import os
 
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_fixed,
+)
+
 import zaza.model as zaza_model
 import zaza.openstack.charm_tests.test_utils as test_utils
 
@@ -43,8 +50,14 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
         zaza_model.set_application_config(self.APPLICATION, config)
         zaza_model.wait_for_application_states()
 
-        configured_ips = zaza_model.run_on_unit(self.UNIT, "ip addr")
-        self.assertIn(self.VIP, configured_ips["Stdout"])
+        for attempt in Retrying(wait=wait_fixed(2),
+                                retry=retry_if_exception_type(AssertionError),
+                                reraise=True,
+                                stop=stop_after_attempt(10)):
+            with attempt:
+                configured_ips = zaza_model.run_on_unit(self.UNIT,
+                                                        "ip addr")
+                self.assertIn(self.VIP, configured_ips["Stdout"])
 
         logging.info("Removing service IP configuration from %s unit.",
                      self.UNIT)

--- a/zaza/openstack/charm_tests/designate_bind/tests.py
+++ b/zaza/openstack/charm_tests/designate_bind/tests.py
@@ -55,8 +55,7 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
                                 reraise=True,
                                 stop=stop_after_attempt(10)):
             with attempt:
-                configured_ips = zaza_model.run_on_unit(self.UNIT,
-                                                        "ip addr")
+                configured_ips = zaza_model.run_on_unit(self.UNIT, "ip addr")
                 self.assertIn(self.VIP, configured_ips["Stdout"])
 
         logging.info("Removing service IP configuration from %s unit.",
@@ -65,5 +64,10 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
         zaza_model.set_application_config(self.APPLICATION, config)
         zaza_model.wait_for_application_states()
 
-        configured_ips = zaza_model.run_on_unit(self.UNIT, "ip addr")
-        self.assertNotIn(self.VIP, configured_ips["Stdout"])
+        for attempt in Retrying(wait=wait_fixed(2),
+                                retry=retry_if_exception_type(AssertionError),
+                                reraise=True,
+                                stop=stop_after_attempt(10)):
+            with attempt:
+                configured_ips = zaza_model.run_on_unit(self.UNIT, "ip addr")
+                self.assertNotIn(self.VIP, configured_ips["Stdout"])

--- a/zaza/openstack/charm_tests/designate_bind/tests.py
+++ b/zaza/openstack/charm_tests/designate_bind/tests.py
@@ -24,6 +24,7 @@ from tenacity import (
 )
 
 import zaza.model as zaza_model
+import zaza.charm_lifecycle.utils as lifecycle_utils
 import zaza.openstack.charm_tests.test_utils as test_utils
 
 
@@ -44,11 +45,13 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
     def test_configure_ips(self):
         """Configure and un-configure 'service_ips' option."""
         config = {"service_ips": self.VIP}
+        test_config = lifecycle_utils.get_charm_config(fatal=False)
+        states = test_config.get("target_deploy_status", {})
 
         logging.info("Configuring %s as a Service IP for %s unit.",
                      self.VIP, self.UNIT)
         zaza_model.set_application_config(self.APPLICATION, config)
-        zaza_model.wait_for_application_states()
+        zaza_model.wait_for_application_states(states=states)
 
         for attempt in Retrying(wait=wait_fixed(2),
                                 retry=retry_if_exception_type(AssertionError),
@@ -62,7 +65,7 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
                      self.UNIT)
         config["service_ips"] = ""
         zaza_model.set_application_config(self.APPLICATION, config)
-        zaza_model.wait_for_application_states()
+        zaza_model.wait_for_application_states(states=states)
 
         for attempt in Retrying(wait=wait_fixed(2),
                                 retry=retry_if_exception_type(AssertionError),


### PR DESCRIPTION
test_configure_ips called wait_for_application_states() with no states, requiring every application active. nrpe is related only to designate (no nagios) so it stays blocked and the wait times out under juju 3.6. Pass target_deploy_status from tests.yaml, matching what DesignateBindExpand already does.