### PR TITLE
Fix designate-bind ServiceIPs test wait states

### DIFF
--- a/zaza/openstack/charm_tests/designate_bind/tests.py
+++ b/zaza/openstack/charm_tests/designate_bind/tests.py
@@ -24,6 +24,7 @@ from tenacity import (
 )
 
 import zaza.model as zaza_model
+import zaza.charm_lifecycle.utils as lifecycle_utils
 import zaza.openstack.charm_tests.test_utils as test_utils
 
 
@@ -44,11 +45,13 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
     def test_configure_ips(self):
         """Configure and un-configure 'service_ips' option."""
         config = {"service_ips": self.VIP}
+        test_config = lifecycle_utils.get_charm_config(fatal=False)
+        states = test_config.get("target_deploy_status", {})
 
         logging.info("Configuring %s as a Service IP for %s unit.",
                      self.VIP, self.UNIT)
         zaza_model.set_application_config(self.APPLICATION, config)
-        zaza_model.wait_for_application_states()
+        zaza_model.wait_for_application_states(states=states)
 
         for attempt in Retrying(wait=wait_fixed(2),
                                 retry=retry_if_exception_type(AssertionError),
@@ -62,7 +65,7 @@ class DesignateBindServiceIPsTest(test_utils.OpenStackBaseTest):
                      self.UNIT)
         config["service_ips"] = ""
         zaza_model.set_application_config(self.APPLICATION, config)
-        zaza_model.wait_for_application_states()
+        zaza_model.wait_for_application_states(states=states)
 
         for attempt in Retrying(wait=wait_fixed(2),
                                 retry=retry_if_exception_type(AssertionError),


### PR DESCRIPTION
test_configure_ips called wait_for_application_states() with no states, requiring every application active. nrpe is related only to designate (no nagios) so it stays blocked and the wait times out under juju 3.6. Pass target_deploy_status from tests.yaml, matching what DesignateBindExpand already does.