### PR TITLE
[bobcat] Ensure no fixed ip for ext port

### DIFF
--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -1019,6 +1019,7 @@ def create_additional_port_for_machines(novaclient, neutronclient, net_id,
                     "name": ext_port_name,
                     "network_id": net_id,
                     "port_security_enabled": False,
+                    "fixed_ips": [],
                 }
             }
             port = neutronclient.create_port(body=body_value)


### PR DESCRIPTION
The external data ports attached to gateways does not need an ip address so we ensure no-fixed-ips. This prevents conflicts with floating ips created in the overlay network.

(cherry picked from commit c47654dfeb2343b92254af666cb026e6b4d1a10f)