### PR TITLE
[Caracal] Convert TEST_*_PROXY to *_proxy env vars

### DIFF
--- a/zaza/openstack/__init__.py
+++ b/zaza/openstack/__init__.py
@@ -18,6 +18,16 @@ import os
 import tempfile
 
 
+def _set_proxy_vars():
+    # Set proxy vars if provided so that all code gets to use it.
+    for key, val in os.environ.items():
+        if not key.startswith('TEST_') or 'PROXY' not in key:
+            continue
+
+        _key = key.partition('TEST_')[2]
+        os.environ[_key.lower()] = val
+
+
 # The temporary directory can't be used when juju's snap is installed in strict
 # mode, so zaza-openstack-tests changes the default tmp directory to the
 # directory referenced by TEST_TMPDIR otherwise a directory is created under
@@ -34,4 +44,5 @@ def _set_tmpdir():
         tempfile.tempdir = tmpdir
 
 
+_set_proxy_vars()
 _set_tmpdir()


### PR DESCRIPTION
If TEST_{NO,HTTP,HTTPS}_PROXY are provided, convert them to http_proxy etc so that code will use them. This will apply to all code under zaza.openstack.

(cherry picked from commit 4b4ececeb070cb32fb57cf8e980cee789ba405d2)