### PR TITLE
[antelope] Convert TEST_*_PROXY to *_proxy env vars

### DIFF
--- a/unit_tests/utilities/test_zaza_utilities_openstack.py
+++ b/unit_tests/utilities/test_zaza_utilities_openstack.py
@@ -1701,6 +1701,7 @@ class TestAsyncOpenstackUtils(ut_utils.AioTestCase):
                     'Stderr': stderr,
                     'Stdout': stdout}}
             return action
+
         results = {
             '/tmp/missing.cert': _get_action_output(
                 '',
@@ -1708,12 +1709,16 @@ class TestAsyncOpenstackUtils(ut_utils.AioTestCase):
                 'cat: /tmp/missing.cert: No such file or directory'),
             '/tmp/good.cert': _get_action_output('CERTIFICATE', '0')}
 
-        async def _run(command, timeout=None):
-            return results[command.split()[-1]]
+        self.patch_object(openstack_utils.zaza.model, "async_run_on_unit")
+
+        async def _run_on_unit(unit_name, command, model_name=None,
+                               timeout=None):
+            return results[command.split()[-1]].data.get('results')
+
+        self.async_run_on_unit.side_effect = _run_on_unit
+
         self.unit1 = mock.MagicMock()
         self.unit2 = mock.MagicMock()
-        self.unit2.run.side_effect = _run
-        self.unit1.run.side_effect = _run
         self.units = [self.unit1, self.unit2]
         _units = mock.MagicMock()
         _units.units = self.units

--- a/zaza/openstack/__init__.py
+++ b/zaza/openstack/__init__.py
@@ -13,3 +13,17 @@
 # limitations under the License.
 
 """OpenStack specific zaza functionality."""
+import os
+
+
+def _set_proxy_vars():
+    # Set proxy vars if provided so that all code gets to use it.
+    for key, val in os.environ.items():
+        if not key.startswith('TEST_') or 'PROXY' not in key:
+            continue
+
+        _key = key.partition('TEST_')[2]
+        os.environ[_key.lower()] = val
+
+
+_set_proxy_vars()

--- a/zaza/openstack/utilities/openstack.py
+++ b/zaza/openstack/utilities/openstack.py
@@ -236,8 +236,12 @@ async def async_block_until_ca_exists(application_name, ca_cert,
         for ca_file in ca_files:
             for unit in units:
                 try:
-                    output = await unit.run('cat {}'.format(ca_file))
-                    contents = output.data.get('results').get('Stdout', '')
+                    output = await zaza.model.async_run_on_unit(
+                        unit.name,
+                        'cat {}'.format(ca_file),
+                        model_name=model_name
+                    )
+                    contents = output.get('Stdout', '')
                     if ca_cert not in contents:
                         break
                 # libjuju throws a generic error for connection failure. So we


### PR DESCRIPTION
If TEST_{NO,HTTP,HTTPS}_PROXY are provided, convert them to http_proxy etc so that code will use them. This will apply to all code under zaza.openstack.

(cherry picked from commit 4b4ececeb070cb32fb57cf8e980cee789ba405d2)