### PR TITLE
[yoga] Convert TEST_*_PROXY to *_proxy env vars

### DIFF
--- a/zaza/openstack/__init__.py
+++ b/zaza/openstack/__init__.py
@@ -13,3 +13,17 @@
 # limitations under the License.
 
 """OpenStack specific zaza functionality."""
+import os
+
+
+def _set_proxy_vars():
+    # Set proxy vars if provided so that all code gets to use it.
+    for key, val in os.environ.items():
+        if not key.startswith('TEST_') or 'PROXY' not in key:
+            continue
+
+        _key = key.partition('TEST_')[2]
+        os.environ[_key.lower()] = val
+
+
+_set_proxy_vars()


### PR DESCRIPTION
If TEST_{NO,HTTP,HTTPS}_PROXY are provided, convert them to http_proxy etc so that code will use them. This will apply to all code under zaza.openstack.

(cherry picked from commit 4b4ececeb070cb32fb57cf8e980cee789ba405d2)