### PR TITLE
Update masakari test to launch jammy instance

### DIFF
--- a/zaza/openstack/charm_tests/masakari/tests.py
+++ b/zaza/openstack/charm_tests/masakari/tests.py
@@ -71,7 +71,7 @@ class MasakariTest(test_utils.OpenStackBaseTest):
         except novaclient.exceptions.NotFound:
             logging.info('Launching new guest')
             guest = zaza.openstack.configure.guest.launch_instance(
-                'bionic',
+                'jammy',
                 use_boot_volume=True,
                 meta={'HA_Enabled': 'True'},
                 vm_name=vm_name)


### PR DESCRIPTION
This is a cherry-pick from 9eac7470a7665837646bd74f51672f2b30a1c777
Without this patch func tests are failing on zed with the:
```
2026-07-17 10:32:09 [INFO] ERROR
2026-07-17 10:32:09 [INFO] ======================================================================
2026-07-17 10:32:09 [INFO] ERROR: test_instance_failover (zaza.openstack.charm_tests.masakari.tests.MasakariTest)
2026-07-17 10:32:09 [INFO] Test masakari managed guest migration.
2026-07-17 10:32:09 [INFO] ----------------------------------------------------------------------
2026-07-17 10:32:09 [INFO] Traceback (most recent call last):
2026-07-17 10:32:09 [INFO]   File "/home/ubuntu/devel/charm-masakari-monitors/src/.tox/func-target/lib/python3.10/site-packages/zaza/openstack/charm_tests/masakari/tests.py", line 69, in ensure_guest
2026-07-17 10:32:09 [INFO]     guest = self.nova_client.servers.find(name=vm_name)
2026-07-17 10:32:09 [INFO]   File "/home/ubuntu/devel/charm-masakari-monitors/src/.tox/func-target/lib/python3.10/site-packages/novaclient/base.py", line 422, in find
2026-07-17 10:32:09 [INFO]     raise exceptions.NotFound(404, msg)
2026-07-17 10:32:09 [INFO] novaclient.exceptions.NotFound: No Server matching {'name': 'zaza-test-instance-failover'}. (HTTP 404)
2026-07-17 10:32:09 [INFO] During handling of the above exception, another exception occurred:
2026-07-17 10:32:09 [INFO] Traceback (most recent call last):
2026-07-17 10:32:09 [INFO]   File "/home/ubuntu/devel/charm-masakari-monitors/src/.tox/func-target/lib/python3.10/site-packages/zaza/openstack/charm_tests/masakari/tests.py", line 168, in test_instance_failover
2026-07-17 10:32:09 [INFO]     self.ensure_guest(vm_name)
2026-07-17 10:32:09 [INFO]   File "/home/ubuntu/devel/charm-masakari-monitors/src/.tox/func-target/lib/python3.10/site-packages/zaza/openstack/charm_tests/masakari/tests.py", line 73, in ensure_guest
2026-07-17 10:32:09 [INFO]     guest = zaza.openstack.configure.guest.launch_instance(
2026-07-17 10:32:09 [INFO]   File "/home/ubuntu/devel/charm-masakari-monitors/src/.tox/func-target/lib/python3.10/site-packages/zaza/openstack/configure/guest.py", line 171, in launch_instance
2026-07-17 10:32:09 [INFO]     image = nova_client.glance.find_image(image_name)
2026-07-17 10:32:09 [INFO]   File "/home/ubuntu/devel/charm-masakari-monitors/src/.tox/func-target/lib/python3.10/site-packages/novaclient/v2/images.py", line 58, in find_image
2026-07-17 10:32:09 [INFO]     raise exceptions.NotFound(404, msg)
2026-07-17 10:32:09 [INFO] novaclient.exceptions.NotFound: No Image matching bionic. (HTTP 404)
```