### PR TITLE
Update masakari test to launch jammy instance

### DIFF
--- a/zaza/openstack/charm_tests/masakari/tests.py
+++ b/zaza/openstack/charm_tests/masakari/tests.py
@@ -71,7 +71,7 @@ class MasakariTest(test_utils.OpenStackBaseTest):
         except novaclient.exceptions.NotFound:
             logging.info('Launching new guest')
             guest = zaza.openstack.configure.guest.launch_instance(
-                'bionic',
+                'jammy',
                 use_boot_volume=True,
                 meta={'HA_Enabled': 'True'},
                 vm_name=vm_name)


### PR DESCRIPTION
This is a cherry-pick from https://github.com/openstack-charmers/zaza-openstack-tests/commit/9eac7470a7665837646bd74f51672f2b30a1c777