### PR TITLE
Fix Manila test NFS mount failure in proxied environments

### DIFF
--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -121,10 +121,6 @@ class ManilaBaseTest(test_utils.OpenStackBaseTest):
 
     RESOURCE_PREFIX = 'zaza-manilatests'
     INSTANCE_KEY = 'jammy'
-    INSTANCE_USERDATA = """#cloud-config
-packages:
-- nfs-common
-"""
 
     @classmethod
     def setUpClass(cls):
@@ -212,6 +208,7 @@ packages:
         :type share_path: string
         """
         ssh_cmd = (
+            'sudo apt-get install -y nfs-common && '
             'sudo mkdir -p {0} && '
             'sudo mount -t {1} -o {2} {3} {0}'.format(
                 self.mount_dir,
@@ -336,11 +333,9 @@ packages:
         # Spawn Servers
         instance_1 = self.launch_guest(
             guest_name='ins-1',
-            userdata=self.INSTANCE_USERDATA,
             instance_key=self.INSTANCE_KEY)
         instance_2 = self.launch_guest(
             guest_name='ins-2',
-            userdata=self.INSTANCE_USERDATA,
             instance_key=self.INSTANCE_KEY)
 
         fip_1 = neutron_tests.floating_ips_from_instance(instance_1)[0]


### PR DESCRIPTION
In proxied environments, the Manila test instances cannot install `nfs-common` via cloud-init because the custom `INSTANCE_USERDATA` lacks proxy configuration. This causes the NFS mount to fail with `bad option; you might need a /sbin/mount.<type> helper program.`

Fix by removing the custom userdata (so the default proxy-aware userdata is used) and installing `nfs-common` via SSH before mounting.