### PR TITLE
[yoga] Add packages option to default userdata for proxied environments

### DIFF
--- a/unit_tests/test_configure_guest.py
+++ b/unit_tests/test_configure_guest.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unit_tests.utils as ut_utils
+
+import zaza.openstack.configure.guest as guest
+
+
+class TestGetDefaultUserdata(ut_utils.BaseTestCase):
+
+    EXPECTED_NO_PACKAGES = """#cloud-config
+apt:
+  http_proxy: http://proxy.example.com:3128
+
+write_files:
+  - path: /etc/environment
+    content: |
+      http_proxy=http://proxy.example.com:3128
+      https_proxy=http://proxy.example.com:3128
+      no_proxy=localhost,127.0.0.1
+    append: true
+
+"""
+
+    EXPECTED_PACKAGES = """#cloud-config
+apt:
+  http_proxy: http://proxy.example.com:3128
+
+write_files:
+  - path: /etc/environment
+    content: |
+      http_proxy=http://proxy.example.com:3128
+      https_proxy=http://proxy.example.com:3128
+      no_proxy=localhost,127.0.0.1
+    append: true
+
+packages:
+- nfs-common
+- curl
+"""
+
+    def setUp(self):
+        super().setUp()
+        self.patch_object(
+            guest.deployment_env, 'get_deployment_context',
+            return_value={
+                'TEST_HTTP_PROXY': 'http://proxy.example.com:3128',
+                'TEST_NO_PROXY': 'localhost,127.0.0.1',
+            })
+
+    def test_without_packages(self):
+        """Test get_default_userdata without packages."""
+        result = guest.get_default_userdata()
+        self.assertEqual(result, self.EXPECTED_NO_PACKAGES)
+
+    def test_with_packages(self):
+        """Test get_default_userdata with multiple packages."""
+        result = guest.get_default_userdata(packages=['nfs-common', 'curl'])
+        self.assertEqual(result, self.EXPECTED_PACKAGES)
+
+    def test_with_empty_packages(self):
+        """Test get_default_userdata with empty packages list."""
+        result = guest.get_default_userdata(packages=[])
+        self.assertEqual(result, self.EXPECTED_NO_PACKAGES)
+
+    def test_with_none_packages(self):
+        """Test get_default_userdata with packages=None."""
+        result = guest.get_default_userdata(packages=None)
+        self.assertEqual(result, self.EXPECTED_NO_PACKAGES)

--- a/zaza/openstack/charm_tests/manila/tests.py
+++ b/zaza/openstack/charm_tests/manila/tests.py
@@ -121,10 +121,7 @@ class ManilaBaseTest(test_utils.OpenStackBaseTest):
 
     RESOURCE_PREFIX = 'zaza-manilatests'
     INSTANCE_KEY = 'bionic'
-    INSTANCE_USERDATA = """#cloud-config
-packages:
-- nfs-common
-"""
+    INSTANCE_PACKAGES = ['nfs-common']
 
     @classmethod
     def setUpClass(cls):
@@ -334,13 +331,14 @@ packages:
         6. Profit
         """
         # Spawn Servers
+        userdata = guest.get_default_userdata(packages=self.INSTANCE_PACKAGES)
         instance_1 = self.launch_guest(
             guest_name='ins-1',
-            userdata=self.INSTANCE_USERDATA,
+            userdata=userdata,
             instance_key=self.INSTANCE_KEY)
         instance_2 = self.launch_guest(
             guest_name='ins-2',
-            userdata=self.INSTANCE_USERDATA,
+            userdata=userdata,
             instance_key=self.INSTANCE_KEY)
 
         fip_1 = neutron_tests.floating_ips_from_instance(instance_1)[0]

--- a/zaza/openstack/charm_tests/octavia/tests.py
+++ b/zaza/openstack/charm_tests/octavia/tests.py
@@ -476,7 +476,7 @@ class LBAASv2Test(test_utils.OpenStackBaseTest):
         # Then we request two Ubuntu instances with the Apache web server
         # installed
         instance_1, instance_2 = self.launch_guests(
-            userdata=get_default_userdata() + 'packages:\n - apache2\n')
+            userdata=get_default_userdata(packages=['apache2']))
 
         # Get IP of the prepared payload instances
         payload_ips = []

--- a/zaza/openstack/configure/guest.py
+++ b/zaza/openstack/configure/guest.py
@@ -45,7 +45,7 @@ write_files:
       no_proxy={no_proxy}
     append: true
 
-"""
+{packages_section}"""
 
 
 boot_tests = {
@@ -67,18 +67,27 @@ boot_tests = {
         'bootstring': 'finished at'}}
 
 
-def get_default_userdata():
+def get_default_userdata(packages=None):
     """
     Get default guest vm userdata.
 
     If http proxy settings are available create a userdata file to enable them
     inside launched guest vms.
+
+    :param packages: Optional list of packages to install via cloud-init.
+    :type packages: Optional[list[str]]
     """
     deploy_env = deployment_env.get_deployment_context()
+    packages_section = ""
+    if packages:
+        packages_section = "packages:\n"
+        packages_section += "\n".join("- {}".format(p) for p in packages)
+        packages_section += "\n"
     return DEFAULT_USER_DATA.format(
         http_proxy=deploy_env.get('TEST_HTTP_PROXY'),
         https_proxy=deploy_env.get('TEST_HTTP_PROXY'),
-        no_proxy=deploy_env.get('TEST_NO_PROXY'))
+        no_proxy=deploy_env.get('TEST_NO_PROXY'),
+        packages_section=packages_section)
 
 
 def launch_instance(instance_key, use_boot_volume=False, vm_name=None,


### PR DESCRIPTION
Add a `packages` parameter to `get_default_userdata()` in guest.py so tests can request cloud-init package installation while inheriting the default proxy settings (`TEST_HTTP_PROXY`, `TEST_NO_PROXY`).

Previously, tests that needed extra packages had to provide their own userdata, which bypassed the proxy configuration and caused apt failures in proxied environments.

- Update Manila tests to use this new option for installing `nfs-common`
- Update Octavia tests to use this instead of string concatenation
- Add unit tests for `get_default_userdata()` with the new `packages` parameter

(cherry picked from commit 329a9628c8b92886965bd4d3046f461b6fc3e898)